### PR TITLE
Update FormState TS definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,7 +37,7 @@ export type FormState = Partial<{
   submitting: boolean
   valid: boolean
   validating: boolean
-  values: object
+  values: { [key: string]: any }
 }>
 
 export type FormSubscriber = Subscriber<FormState>


### PR DESCRIPTION
Defining the 'values' property of FormState as 'object' forces one to reference keys via bracket notation. Using dot notation results in: Property 'myprop' does not exist on type 'object'. Redefining 'values' as '{ [key: string]: any }' lets one use dot notation.