### PR TITLE
Fix ts defs and add index.d.test.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3213,12 +3213,6 @@
         "write": "0.2.1"
       }
     },
-    "flow": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/flow/-/flow-0.2.3.tgz",
-      "integrity": "sha1-+Npl76JJEn7Jk3aiiJZXKpeV0a8=",
-      "dev": true
-    },
     "flow-bin": {
       "version": "0.61.0",
       "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.61.0.tgz",
@@ -9031,6 +9025,42 @@
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "diff": "3.4.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "2.16.0"
+      }
+    },
+    "tsutils": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.16.0.tgz",
+      "integrity":
+        "sha512-9Ier/60O7OZRNPiw+or5QAtAY4kQA+WDiO/r6xOYATEyefH9bdfvTRLCxrYnFhQlZfET2vYXKfpr3Vw2BiArZw==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -64,10 +64,20 @@ module.exports = {
       description: 'flow check the entire project',
       script: 'flow check'
     },
+    typescript: {
+      description: 'typescript check the entire project',
+      script: 'tsc'
+    },
     validate: {
       description:
         'This runs several scripts to make sure things look good before committing or on clean install',
-      default: concurrent.nps('lint', 'flow', 'build.andTest', 'test')
+      default: concurrent.nps(
+        'lint',
+        'flow',
+        'typescript',
+        'build.andTest',
+        'test'
+      )
     }
   },
   options: {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "rollup-plugin-flow": "^1.1.1",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^2.0.0",
-    "rollup-plugin-uglify": "^2.0.1"
+    "rollup-plugin-uglify": "^2.0.1",
+    "tslint": "^5.9.1",
+    "typescript": "^2.6.2"
   },
   "lint-staged": {
     "*.{js*,ts,json,md,css}": ["prettier --write", "git add"]

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable no-console
 
-import { Config, createForm } from 'final-form'
+import { Config, createForm } from './index'
 
 const onSubmit: Config['onSubmit'] = (values, callback) => {}
 

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -1,0 +1,21 @@
+// tslint:disable no-console
+
+import { Config, createForm } from 'final-form'
+
+const onSubmit: Config['onSubmit'] = (values, callback) => {}
+
+let form = createForm({ onSubmit })
+
+console.log(form.getState().initialValues as { [key: string]: any })
+console.log(form.getState().values as { [key: string]: any })
+
+const initialValues: Config['initialValues'] = {
+  a: 'a',
+  b: true,
+  c: 1
+}
+
+form = createForm({ onSubmit, initialValues })
+
+console.log(form.getState().pristine as boolean)
+console.log(form.getState().dirty as boolean)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,218 +1,216 @@
-declare module 'final-form' {
-  export interface Subscription {
-    [key: string]: boolean
-  }
-  export type Subscriber<V> = (value: V) => void
-  export type IsEqual = (a: any, b: any) => boolean
-
-  export interface FormSubscription extends Partial<Subscription> {
-    active: boolean
-    dirty: boolean
-    dirtySinceLastSubmit: boolean
-    error: boolean
-    errors: boolean
-    initialValues: boolean
-    invalid: boolean
-    pristine: boolean
-    submitError: boolean
-    submitErrors: boolean
-    submitFailed: boolean
-    submitSucceeded: boolean
-    submitting: boolean
-    valid: boolean
-    validating: boolean
-    values: boolean
-  }
-
-  export interface FormState {
-    active: string
-    dirty: boolean
-    dirtySinceLastSubmit: boolean
-    error: any
-    errors: object
-    initialValues: object
-    invalid: boolean
-    pristine: boolean
-    submitError: any
-    submitErrors: object
-    submitFailed: boolean
-    submitSucceeded: boolean
-    submitting: boolean
-    valid: boolean
-    validating: boolean
-    values: { [key: string]: any }
-  }
-
-  export type FormSubscriber = Subscriber<FormState>
-
-  export interface FieldState {
-    active?: boolean
-    blur: () => void
-    change: (value: any) => void
-    data?: object
-    dirty?: boolean
-    dirtySinceLastSubmit?: boolean
-    error?: any
-    focus: () => void
-    initial?: any
-    invalid?: boolean
-    length?: number
-    name: string
-    pristine?: boolean
-    submitError?: any
-    submitFailed?: boolean
-    submitSucceeded?: boolean
-    touched?: boolean
-    valid?: boolean
-    value?: any
-    visited?: boolean
-  }
-
-  export interface FieldSubscription extends Partial<Subscription> {
-    active: boolean
-    data: boolean
-    dirty: boolean
-    dirtySinceLastSubmit: boolean
-    error: boolean
-    initial: boolean
-    invalid: boolean
-    length: boolean
-    pristine: boolean
-    submitError: boolean
-    submitFailed: boolean
-    submitSucceeded: boolean
-    touched: boolean
-    valid: boolean
-    value: boolean
-    visited: boolean
-  }
-
-  export type FieldSubscriber = Subscriber<FieldState>
-
-  export type Unsubscribe = () => void
-
-  type FieldValidator = (value: any, allValues: object) => any | Promise<any>
-  type GetFieldValidator = () => FieldValidator
-
-  export interface FieldConfig {
-    isEqual?: IsEqual
-    getValidator?: GetFieldValidator
-    validateFields?: string[]
-  }
-
-  export type RegisterField = (
-    name: string,
-    subscriber: FieldSubscriber,
-    subscription: FieldSubscription,
-    config: FieldConfig
-  ) => Unsubscribe
-
-  export interface InternalFieldState {
-    active: boolean
-    blur: () => void
-    change: (value: any) => void
-    data: object
-    error?: any
-    focus: () => void
-    isEqual: IsEqual
-    lastFieldState?: FieldState
-    length?: any
-    name: string
-    submitError?: any
-    pristine: boolean
-    touched: boolean
-    validateFields?: string[]
-    validators: {
-      [index: number]: GetFieldValidator
-    }
-    valid: boolean
-    visited: boolean
-  }
-
-  export interface InternalFormState {
-    active?: string
-    dirtySinceLastSubmit: boolean
-    error?: any
-    errors: object
-    initialValues?: object
-    lastSubmittedValues?: object
-    pristine: boolean
-    submitError?: any
-    submitErrors?: object
-    submitFailed: boolean
-    submitSucceeded: boolean
-    submitting: boolean
-    valid: boolean
-    validating: number
-    values: object
-  }
-
-  export interface FormApi {
-    batch: (fn: () => void) => void
-    blur: (name: string) => void
-    change: (name: string, value?: any) => void
-    focus: (name: string) => void
-    initialize: (values: object) => void
-    getRegisteredFields: () => string[]
-    getState: () => FormState
-    mutators?: { [key: string]: Function }
-    submit: () => Promise<object | undefined> | undefined
-    subscribe: (
-      subscriber: FormSubscriber,
-      subscription: FormSubscription
-    ) => Unsubscribe
-    registerField: RegisterField
-    reset: () => void
-  }
-
-  export type DebugFunction = (
-    state: FormState,
-    fieldStates: { [key: string]: FieldState }
-  ) => void
-
-  export interface MutableState {
-    formState: InternalFormState
-    fields: {
-      [key: string]: InternalFieldState
-    }
-  }
-
-  export type GetIn = (state: object, complexKey: string) => any
-  export type SetIn = (state: object, key: string, value: any) => object
-  export type ChangeValue = (
-    state: MutableState,
-    name: string,
-    mutate: (value: any) => any
-  ) => void
-  export interface Tools {
-    changeValue: ChangeValue
-    getIn: GetIn
-    setIn: SetIn
-    shallowEqual: IsEqual
-  }
-
-  export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
-
-  export interface Config {
-    debug?: DebugFunction
-    initialValues?: object
-    mutators?: { [key: string]: Mutator }
-    onSubmit: (
-      values: object,
-      form: FormApi,
-      callback?: (errors?: object) => void
-    ) => object | Promise<object | undefined> | undefined | void
-    validate?: (values: object) => object | Promise<object>
-    validateOnBlur?: boolean
-  }
-
-  export type Decorator = (form: FormApi) => Unsubscribe
-
-  export function createForm(config: Config): FormApi
-  export const fieldSubscriptionItems: string[]
-  export const formSubscriptionItems: string[]
-  export const FORM_ERROR: any
-  export function getIn(state: object, complexKey: string): any
-  export function setIn(state: object, key: string, value: any): object
-  export const version: string
+export interface Subscription {
+  [key: string]: boolean
 }
+export type Subscriber<V> = (value: V) => void
+export type IsEqual = (a: any, b: any) => boolean
+
+export interface FormSubscription extends Partial<Subscription> {
+  active: boolean
+  dirty: boolean
+  dirtySinceLastSubmit: boolean
+  error: boolean
+  errors: boolean
+  initialValues: boolean
+  invalid: boolean
+  pristine: boolean
+  submitError: boolean
+  submitErrors: boolean
+  submitFailed: boolean
+  submitSucceeded: boolean
+  submitting: boolean
+  valid: boolean
+  validating: boolean
+  values: boolean
+}
+
+export interface FormState {
+  active: string
+  dirty: boolean
+  dirtySinceLastSubmit: boolean
+  error: any
+  errors: object
+  initialValues: object
+  invalid: boolean
+  pristine: boolean
+  submitError: any
+  submitErrors: object
+  submitFailed: boolean
+  submitSucceeded: boolean
+  submitting: boolean
+  valid: boolean
+  validating: boolean
+  values: { [key: string]: any }
+}
+
+export type FormSubscriber = Subscriber<FormState>
+
+export interface FieldState {
+  active?: boolean
+  blur: () => void
+  change: (value: any) => void
+  data?: object
+  dirty?: boolean
+  dirtySinceLastSubmit?: boolean
+  error?: any
+  focus: () => void
+  initial?: any
+  invalid?: boolean
+  length?: number
+  name: string
+  pristine?: boolean
+  submitError?: any
+  submitFailed?: boolean
+  submitSucceeded?: boolean
+  touched?: boolean
+  valid?: boolean
+  value?: any
+  visited?: boolean
+}
+
+export interface FieldSubscription extends Partial<Subscription> {
+  active: boolean
+  data: boolean
+  dirty: boolean
+  dirtySinceLastSubmit: boolean
+  error: boolean
+  initial: boolean
+  invalid: boolean
+  length: boolean
+  pristine: boolean
+  submitError: boolean
+  submitFailed: boolean
+  submitSucceeded: boolean
+  touched: boolean
+  valid: boolean
+  value: boolean
+  visited: boolean
+}
+
+export type FieldSubscriber = Subscriber<FieldState>
+
+export type Unsubscribe = () => void
+
+type FieldValidator = (value: any, allValues: object) => any | Promise<any>
+type GetFieldValidator = () => FieldValidator
+
+export interface FieldConfig {
+  isEqual?: IsEqual
+  getValidator?: GetFieldValidator
+  validateFields?: string[]
+}
+
+export type RegisterField = (
+  name: string,
+  subscriber: FieldSubscriber,
+  subscription: FieldSubscription,
+  config: FieldConfig
+) => Unsubscribe
+
+export interface InternalFieldState {
+  active: boolean
+  blur: () => void
+  change: (value: any) => void
+  data: object
+  error?: any
+  focus: () => void
+  isEqual: IsEqual
+  lastFieldState?: FieldState
+  length?: any
+  name: string
+  submitError?: any
+  pristine: boolean
+  touched: boolean
+  validateFields?: string[]
+  validators: {
+    [index: number]: GetFieldValidator
+  }
+  valid: boolean
+  visited: boolean
+}
+
+export interface InternalFormState {
+  active?: string
+  dirtySinceLastSubmit: boolean
+  error?: any
+  errors: object
+  initialValues?: object
+  lastSubmittedValues?: object
+  pristine: boolean
+  submitError?: any
+  submitErrors?: object
+  submitFailed: boolean
+  submitSucceeded: boolean
+  submitting: boolean
+  valid: boolean
+  validating: number
+  values: object
+}
+
+export interface FormApi {
+  batch: (fn: () => void) => void
+  blur: (name: string) => void
+  change: (name: string, value?: any) => void
+  focus: (name: string) => void
+  initialize: (values: object) => void
+  getRegisteredFields: () => string[]
+  getState: () => FormState
+  mutators?: { [key: string]: Function }
+  submit: () => Promise<object | undefined> | undefined
+  subscribe: (
+    subscriber: FormSubscriber,
+    subscription: FormSubscription
+  ) => Unsubscribe
+  registerField: RegisterField
+  reset: () => void
+}
+
+export type DebugFunction = (
+  state: FormState,
+  fieldStates: { [key: string]: FieldState }
+) => void
+
+export interface MutableState {
+  formState: InternalFormState
+  fields: {
+    [key: string]: InternalFieldState
+  }
+}
+
+export type GetIn = (state: object, complexKey: string) => any
+export type SetIn = (state: object, key: string, value: any) => object
+export type ChangeValue = (
+  state: MutableState,
+  name: string,
+  mutate: (value: any) => any
+) => void
+export interface Tools {
+  changeValue: ChangeValue
+  getIn: GetIn
+  setIn: SetIn
+  shallowEqual: IsEqual
+}
+
+export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
+
+export interface Config {
+  debug?: DebugFunction
+  initialValues?: object
+  mutators?: { [key: string]: Mutator }
+  onSubmit: (
+    values: object,
+    form: FormApi,
+    callback?: (errors?: object) => void
+  ) => object | Promise<object | undefined> | undefined | void
+  validate?: (values: object) => object | Promise<object>
+  validateOnBlur?: boolean
+}
+
+export type Decorator = (form: FormApi) => Unsubscribe
+
+export function createForm(config: Config): FormApi
+export const fieldSubscriptionItems: string[]
+export const formSubscriptionItems: string[]
+export const FORM_ERROR: any
+export function getIn(state: object, complexKey: string): any
+export function setIn(state: object, key: string, value: any): object
+export const version: string

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,22 +24,23 @@ export interface FormSubscription extends Partial<Subscription> {
 }
 
 export interface FormState {
-  active: string
-  dirty: boolean
-  dirtySinceLastSubmit: boolean
-  error: any
-  errors: object
-  initialValues: object
-  invalid: boolean
-  pristine: boolean
-  submitError: any
-  submitErrors: object
-  submitFailed: boolean
-  submitSucceeded: boolean
-  submitting: boolean
-  valid: boolean
-  validating: boolean
-  values: { [key: string]: any }
+  // all values are optional because they must be subscribed to
+  active?: string
+  dirty?: boolean
+  dirtySinceLastSubmit?: boolean
+  error?: any
+  errors?: object
+  initialValues?: object
+  invalid?: boolean
+  pristine?: boolean
+  submitError?: any
+  submitErrors?: object
+  submitFailed?: boolean
+  submitSucceeded?: boolean
+  submitting?: boolean
+  valid?: boolean
+  validating?: boolean
+  values?: { [key: string]: any }
 }
 
 export type FormSubscriber = Subscriber<FormState>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,217 +1,217 @@
-export interface Subscription {
-  [key: string]: boolean
-}
-export type Subscriber<V> = (value: V) => void
-export type IsEqual = (a: any, b: any) => boolean
-
-export interface FormSubscription extends Subscription {
-  active?: boolean
-  dirty?: boolean
-  dirtySinceLastSubmit?: boolean
-  error?: boolean
-  errors?: boolean
-  initialValues?: boolean
-  invalid?: boolean
-  pristine?: boolean
-  submitError?: boolean
-  submitErrors?: boolean
-  submitFailed?: boolean
-  submitSucceeded?: boolean
-  submitting?: boolean
-  valid?: boolean
-  validating?: boolean
-  values?: boolean
-}
-
-export interface FormState {
-  // all values are optional because they must be subscribed to
-  active?: string
-  dirty?: boolean
-  dirtySinceLastSubmit?: boolean
-  error?: any
-  errors?: object
-  initialValues?: object
-  invalid?: boolean
-  pristine?: boolean
-  submitError?: any
-  submitErrors?: object
-  submitFailed?: boolean
-  submitSucceeded: boolean
-  submitting?: boolean
-  valid?: boolean
-  validating?: boolean
-  values?: { [key: string]: any }
-}
-
-export type FormSubscriber = Subscriber<FormState>
-
-export interface FieldState {
-  active?: boolean
-  blur: () => void
-  change: (value: any) => void
-  data?: object
-  dirty?: boolean
-  dirtySinceLastSubmit?: boolean
-  error?: any
-  focus: () => void
-  initial?: any
-  invalid?: boolean
-  length?: number
-  name: string
-  pristine?: boolean
-  submitError?: any
-  submitFailed?: boolean
-  submitSucceeded?: boolean
-  touched?: boolean
-  valid?: boolean
-  value?: any
-  visited?: boolean
-}
-
-export interface FieldSubscription extends Subscription {
-  active?: boolean
-  data?: boolean
-  dirty?: boolean
-  dirtySinceLastSubmit?: boolean
-  error?: boolean
-  initial?: boolean
-  invalid?: boolean
-  length?: boolean
-  pristine?: boolean
-  submitError?: boolean
-  submitFailed?: boolean
-  submitSucceeded?: boolean
-  touched?: boolean
-  valid?: boolean
-  value?: boolean
-  visited?: boolean
-}
-
-export type FieldSubscriber = Subscriber<FieldState>
-
-export type Unsubscribe = () => void
-
-type FieldValidator = (value: any, allValues: object) => any | Promise<any>
-type GetFieldValidator = () => FieldValidator
-
-export interface FieldConfig {
-  isEqual?: IsEqual
-  getValidator?: GetFieldValidator
-  validateFields?: string[]
-}
-
-export type RegisterField = (
-  name: string,
-  subscriber: FieldSubscriber,
-  subscription: FieldSubscription,
-  config: FieldConfig
-) => Unsubscribe
-
-export interface InternalFieldState {
-  active: boolean
-  blur: () => void
-  change: (value: any) => void
-  data: object
-  error?: any
-  focus: () => void
-  isEqual: IsEqual
-  lastFieldState?: FieldState
-  length?: any
-  name: string
-  submitError?: any
-  pristine: boolean
-  touched: boolean
-  validateFields?: string[]
-  validators: {
-    [index: number]: GetFieldValidator
+declare module 'final-form' {
+  export interface Subscription {
+    [key: string]: boolean
   }
-  valid: boolean
-  visited: boolean
-}
+  export type Subscriber<V> = (value: V) => void
+  export type IsEqual = (a: any, b: any) => boolean
 
-export interface InternalFormState {
-  active?: string
-  dirtySinceLastSubmit: boolean
-  error?: any
-  errors: object
-  initialValues?: object
-  lastSubmittedValues?: object
-  pristine: boolean
-  submitError?: any
-  submitErrors?: object
-  submitFailed: boolean
-  submitSucceeded: boolean
-  submitting: boolean
-  valid: boolean
-  validating: number
-  values: object
-}
+  export interface FormSubscription extends Partial<Subscription> {
+    active: boolean
+    dirty: boolean
+    dirtySinceLastSubmit: boolean
+    error: boolean
+    errors: boolean
+    initialValues: boolean
+    invalid: boolean
+    pristine: boolean
+    submitError: boolean
+    submitErrors: boolean
+    submitFailed: boolean
+    submitSucceeded: boolean
+    submitting: boolean
+    valid: boolean
+    validating: boolean
+    values: boolean
+  }
 
-export interface FormApi {
-  batch: (fn: () => void) => void
-  blur: (name: string) => void
-  change: (name: string, value?: any) => void
-  focus: (name: string) => void
-  initialize: (values: object) => void
-  getRegisteredFields: () => string[]
-  getState: () => FormState
-  mutators?: { [key: string]: Function }
-  submit: () => Promise<object | undefined> | undefined
-  subscribe: (
-    subscriber: FormSubscriber,
-    subscription: FormSubscription
+  export interface FormState {
+    active: string
+    dirty: boolean
+    dirtySinceLastSubmit: boolean
+    error: any
+    errors: object
+    initialValues: object
+    invalid: boolean
+    pristine: boolean
+    submitError: any
+    submitErrors: object
+    submitFailed: boolean
+    submitSucceeded: boolean
+    submitting: boolean
+    valid: boolean
+    validating: boolean
+    values: { [key: string]: any }
+  }
+
+  export type FormSubscriber = Subscriber<FormState>
+
+  export interface FieldState {
+    active?: boolean
+    blur: () => void
+    change: (value: any) => void
+    data?: object
+    dirty?: boolean
+    dirtySinceLastSubmit?: boolean
+    error?: any
+    focus: () => void
+    initial?: any
+    invalid?: boolean
+    length?: number
+    name: string
+    pristine?: boolean
+    submitError?: any
+    submitFailed?: boolean
+    submitSucceeded?: boolean
+    touched?: boolean
+    valid?: boolean
+    value?: any
+    visited?: boolean
+  }
+
+  export interface FieldSubscription extends Partial<Subscription> {
+    active: boolean
+    data: boolean
+    dirty: boolean
+    dirtySinceLastSubmit: boolean
+    error: boolean
+    initial: boolean
+    invalid: boolean
+    length: boolean
+    pristine: boolean
+    submitError: boolean
+    submitFailed: boolean
+    submitSucceeded: boolean
+    touched: boolean
+    valid: boolean
+    value: boolean
+    visited: boolean
+  }
+
+  export type FieldSubscriber = Subscriber<FieldState>
+
+  export type Unsubscribe = () => void
+
+  type FieldValidator = (value: any, allValues: object) => any | Promise<any>
+  type GetFieldValidator = () => FieldValidator
+
+  export interface FieldConfig {
+    isEqual?: IsEqual
+    getValidator?: GetFieldValidator
+    validateFields?: string[]
+  }
+
+  export type RegisterField = (
+    name: string,
+    subscriber: FieldSubscriber,
+    subscription: FieldSubscription,
+    config: FieldConfig
   ) => Unsubscribe
-  registerField: RegisterField
-  reset: () => void
-}
 
-export type DebugFunction = (
-  state: FormState,
-  fieldStates: { [key: string]: FieldState }
-) => void
-
-export interface MutableState {
-  formState: InternalFormState
-  fields: {
-    [key: string]: InternalFieldState
+  export interface InternalFieldState {
+    active: boolean
+    blur: () => void
+    change: (value: any) => void
+    data: object
+    error?: any
+    focus: () => void
+    isEqual: IsEqual
+    lastFieldState?: FieldState
+    length?: any
+    name: string
+    submitError?: any
+    pristine: boolean
+    touched: boolean
+    validateFields?: string[]
+    validators: {
+      [index: number]: GetFieldValidator
+    }
+    valid: boolean
+    visited: boolean
   }
+
+  export interface InternalFormState {
+    active?: string
+    dirtySinceLastSubmit: boolean
+    error?: any
+    errors: object
+    initialValues?: object
+    lastSubmittedValues?: object
+    pristine: boolean
+    submitError?: any
+    submitErrors?: object
+    submitFailed: boolean
+    submitSucceeded: boolean
+    submitting: boolean
+    valid: boolean
+    validating: number
+    values: object
+  }
+
+  export interface FormApi {
+    batch: (fn: () => void) => void
+    blur: (name: string) => void
+    change: (name: string, value?: any) => void
+    focus: (name: string) => void
+    initialize: (values: object) => void
+    getRegisteredFields: () => string[]
+    getState: () => FormState
+    mutators?: { [key: string]: Function }
+    submit: () => Promise<object | undefined> | undefined
+    subscribe: (
+      subscriber: FormSubscriber,
+      subscription: FormSubscription
+    ) => Unsubscribe
+    registerField: RegisterField
+    reset: () => void
+  }
+
+  export type DebugFunction = (
+    state: FormState,
+    fieldStates: { [key: string]: FieldState }
+  ) => void
+
+  export interface MutableState {
+    formState: InternalFormState
+    fields: {
+      [key: string]: InternalFieldState
+    }
+  }
+
+  export type GetIn = (state: object, complexKey: string) => any
+  export type SetIn = (state: object, key: string, value: any) => object
+  export type ChangeValue = (
+    state: MutableState,
+    name: string,
+    mutate: (value: any) => any
+  ) => void
+  export interface Tools {
+    changeValue: ChangeValue
+    getIn: GetIn
+    setIn: SetIn
+    shallowEqual: IsEqual
+  }
+
+  export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
+
+  export interface Config {
+    debug?: DebugFunction
+    initialValues?: object
+    mutators?: { [key: string]: Mutator }
+    onSubmit: (
+      values: object,
+      form: FormApi,
+      callback?: (errors?: object) => void
+    ) => object | Promise<object | undefined> | undefined | void
+    validate?: (values: object) => object | Promise<object>
+    validateOnBlur?: boolean
+  }
+
+  export type Decorator = (form: FormApi) => Unsubscribe
+
+  export function createForm(config: Config): FormApi
+  export const fieldSubscriptionItems: string[]
+  export const formSubscriptionItems: string[]
+  export const FORM_ERROR: any
+  export function getIn(state: object, complexKey: string): any
+  export function setIn(state: object, key: string, value: any): object
 }
-
-export type GetIn = (state: object, complexKey: string) => any
-export type SetIn = (state: object, key: string, value: any) => object
-export type ChangeValue = (
-  state: MutableState,
-  name: string,
-  mutate: (value: any) => any
-) => void
-export interface Tools {
-  changeValue: ChangeValue
-  getIn: GetIn
-  setIn: SetIn
-  shallowEqual: IsEqual
-}
-
-export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
-
-export interface Config {
-  debug?: DebugFunction
-  initialValues?: object
-  mutators?: { [key: string]: Mutator }
-  onSubmit: (
-    values: object,
-    form: FormApi,
-    callback?: (errors?: object) => void
-  ) => object | Promise<object | undefined> | undefined | void
-  validate?: (values: object) => object | Promise<object>
-  validateOnBlur?: boolean
-}
-
-export type Decorator = (form: FormApi) => Unsubscribe
-
-export function createForm(config: Config): FormApi
-export var fieldSubscriptionItems: string[]
-export var formSubscriptionItems: string[]
-export var FORM_ERROR: any
-export function getIn(state: object, complexKey: string): any
-export function setIn(state: object, key: string, value: any): object
-export var version: string

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -214,4 +214,5 @@ declare module 'final-form' {
   export const FORM_ERROR: any
   export function getIn(state: object, complexKey: string): any
   export function setIn(state: object, key: string, value: any): object
+  export const version: string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "noEmit": true,
+    "strict": true
+  },
+  "files": ["src/index.d.ts", "src/index.d.test.ts"]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,7 @@
+{
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "jsRules": {},
+  "rules": {},
+  "rulesDirectory": []
+}


### PR DESCRIPTION
Based on issue https://github.com/final-form/react-final-form/issues/108 here is a fix for ts regression described on screenshot of this issue.

I've added a demo ts file so you can run compilation on CI and prevent any other regression (or at least if tested). For now the test cover only form creation and I havn't added the required command in build/ci script.

the command is just `node_modules/.bin/tsc`

I've reverted most changes from #54 because it causes regression and this is not the way to use typescript. If you want a partial interface then just use `Partial<MyInterface>`, if you want only a single def then you use `MyInterface['singleField']` adding `?` is not the way to do.

Tell me if you have question.

Thanks :+1: 