### PR TITLE
Ensure `mutators` is defined to avoid bad strongly typed developer casting experienc

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/final-form.cjs.js",
   "jsnext:main": "dist/final-form.es.js",
   "module": "dist/final-form.es.js",
-  "typings": "dist/index.d.js",
+  "typings": "dist/index.d.ts",
   "files": ["dist"],
   "scripts": {
     "start": "nps",

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -185,7 +185,7 @@ const createForm = (config: Config): FormApi => {
         return returnValue
       }
       return result
-    }, {})
+    }, {}) || {}
 
   const runRecordLevelValidation = (
     setErrors: (errors: Object) => void

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable no-console
 
-import {Config, createForm, AnyObject} from './index'
+import {Config, createForm, AnyObject, Mutator} from './index'
 
 const onSubmit: Config['onSubmit'] = (values, callback) => {}
 
@@ -39,3 +39,19 @@ console.log(formState.dirty as boolean)
 // subscription
 form = createForm({ onSubmit, initialValues })
 form.subscribe((state) => {}, { pristine: true })
+
+
+// mutators
+const setValue: Mutator = ([name, newValue], state, { changeValue }) => {
+  changeValue(state, name, value => newValue)
+}
+
+type Mutators = { setValue: (name: string, value: string) => void }
+form = createForm({
+  mutators: { setValue },
+  onSubmit
+})
+
+// Get form.mutators cast to Mutators
+const mutators: Mutators = form.mutators as Mutators
+mutators.setValue('firstName', 'Kevin')

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -153,7 +153,7 @@ export interface FormApi {
   initialize: (values: object) => void
   getRegisteredFields: () => string[]
   getState: () => FormState
-  mutators?: { [key: string]: Function }
+  mutators: { [key: string]: Function }
   submit: () => Promise<object | undefined> | undefined
   subscribe: (
     subscriber: FormSubscriber,

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -153,7 +153,7 @@ export type FormApi = {
   initialize: (values: Object) => void,
   getRegisteredFields: () => string[],
   getState: () => FormState,
-  mutators: ?{ [string]: Function },
+  mutators: { [string]: Function },
   submit: () => ?Promise<?Object>,
   subscribe: (
     subscriber: FormSubscriber,


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
I have peeled all layers of the onion.  This is the first domino that needs to fall.

Strongly typed users when attempting to use `mutators` in a form render will have to cast as it may be `undefined`.  This can be a painful and likely unnecessary experience.  This simple change will bring joy and sunshine to the lives of typescript developers far and wide.

https://github.com/final-form/react-final-form/pull/129 depends on this, as do PRs in the arrays projects.

@erikras please review this one first.
