### PR TITLE
Add method for setting config value after form creation

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -666,6 +666,10 @@ const createForm = (config: Config): FormApi => {
           break
         case 'validate':
           validate = value
+          runValidation(undefined, () => {
+            notifyFieldListeners()
+            notifyFormListeners()
+          })
           break
         case 'validateOnBlur':
           validateOnBlur = value

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -173,27 +173,27 @@ const createForm = (config: Config): FormApi => {
 
   // bind state to mutators
   const getMutatorApi = key => (...args) => {
-    if (!mutators) {
-      throw new Error('mutators should not be null or undefined')
+    if (mutators) {
+      const mutatableState = {
+        formState: state.formState,
+        fields: state.fields
+      }
+      const returnValue = mutators[key](args, mutatableState, {
+        changeValue,
+        getIn,
+        setIn,
+        shallowEqual
+      })
+      state.formState = mutatableState.formState
+      state.fields = mutatableState.fields
+      runValidation(undefined, () => {
+        notifyFieldListeners()
+        notifyFormListeners()
+      })
+      return returnValue
     }
-    const mutatableState = {
-      formState: state.formState,
-      fields: state.fields
-    }
-    const returnValue = mutators[key](args, mutatableState, {
-      changeValue,
-      getIn,
-      setIn,
-      shallowEqual
-    })
-    state.formState = mutatableState.formState
-    state.fields = mutatableState.fields
-    runValidation(undefined, () => {
-      notifyFieldListeners()
-      notifyFormListeners()
-    })
-    return returnValue
   }
+  
   const mutatorsApi =
     (mutators &&
       Object.keys(mutators).reduce((result, key) => {

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -22,7 +22,6 @@ import type {
   InternalFormState,
   IsEqual,
   MutableState,
-  Mutator,
   Subscriber,
   Subscription,
   Unsubscribe

--- a/src/FinalForm.setConfig.test.js
+++ b/src/FinalForm.setConfig.test.js
@@ -1,6 +1,5 @@
 import createForm from './FinalForm'
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 const onSubmitMock = (values, callback) => {}
 
 describe('FinalForm.setConfig', () => {

--- a/src/FinalForm.setConfig.test.js
+++ b/src/FinalForm.setConfig.test.js
@@ -1,0 +1,215 @@
+import createForm from './FinalForm'
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const onSubmitMock = (values, callback) => {}
+
+describe('FinalForm.setConfig', () => {
+  it('should update debug callback on setConfig("debug", fn)', () => {
+    const debug = jest.fn()
+    const form = createForm({ onSubmit: onSubmitMock })
+
+    form.registerField('foo', () => {})
+    expect(debug).toHaveBeenCalledTimes(0)
+
+    form.change('foo', 'bar')
+
+    expect(debug).toHaveBeenCalledTimes(0)
+
+    form.setConfig('debug', debug)
+
+    form.change('foo', 'bing')
+
+    expect(debug).toHaveBeenCalledTimes(1)
+  })
+
+  it('should initialize the form on setConfig("initialValues", values)', () => {
+    const form = createForm({
+      onSubmit: onSubmitMock,
+      initialValues: {
+        foo: 'bar'
+      }
+    })
+    const spy = jest.fn()
+    form.registerField('foo', spy, { initial: true })
+
+    // should initialize with initial value
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0].initial).toBe('bar')
+
+    form.reset()
+
+    // same initial value, duh
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    form.setConfig('initialValues', { foo: 'baz' })
+
+    // new initial value
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0].initial).toBe('baz')
+  })
+
+  it('should update mutators on setConfig("mutators", mutators)', () => {
+    const clear = jest.fn(([name], state, { changeValue }) => {
+      changeValue(state, name, () => undefined)
+    })
+    const upper = jest.fn(([name], state, { changeValue }) => {
+      changeValue(state, name, value => value && value.toUpperCase())
+    })
+
+    const form = createForm({
+      onSubmit: onSubmitMock,
+      mutators: { clear }
+    })
+    expect(form.mutators).toBeDefined()
+    expect(form.mutators.clear).toBeDefined()
+    expect(typeof form.mutators.clear).toBe('function')
+    expect(typeof form.mutators.upper).toBe('undefined')
+
+    form.setConfig('mutators', { clear, upper })
+
+    expect(form.mutators.upper).toBeDefined()
+    expect(typeof form.mutators.upper).toBe('function')
+
+    const formListener = jest.fn()
+    form.subscribe(formListener, { values: true })
+    form.registerField('foo', () => {}, { value: true })
+
+    expect(formListener).toHaveBeenCalledTimes(1)
+    expect(formListener.mock.calls[0][0].values).toEqual({})
+
+    form.change('foo', 'bar')
+
+    expect(formListener).toHaveBeenCalledTimes(2)
+    expect(formListener.mock.calls[1][0].values.foo).toBe('bar')
+
+    form.mutators.upper('foo')
+
+    expect(formListener).toHaveBeenCalledTimes(3)
+    expect(formListener.mock.calls[2][0].values.foo).toBe('BAR')
+
+    form.mutators.clear('foo')
+
+    expect(formListener).toHaveBeenCalledTimes(4)
+    expect(formListener.mock.calls[3][0].values.foo).toBeUndefined()
+
+    form.setConfig('mutators', { upper })
+    expect(typeof form.mutators.clear).toBe('undefined')
+
+    form.setConfig('mutators', undefined)
+    expect(typeof form.mutators.clear).toBe('undefined')
+    expect(typeof form.mutators.upper).toBe('undefined')
+  })
+
+  it('should replace onSubmit on setConfig("onSubmit", fn)', () => {
+    const onSubmit = jest.fn()
+    const form = createForm({ onSubmit })
+    form.registerField('foo', () => {})
+    form.registerField('foo2', () => {})
+
+    form.change('foo', 'bar')
+    form.change('foo2', 'baz')
+
+    const onSubmitReplacement = jest.fn()
+    form.setConfig('onSubmit', onSubmitReplacement)
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onSubmitReplacement).not.toHaveBeenCalled()
+    form.submit()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onSubmitReplacement.mock.calls[0][0]).toEqual({
+      foo: 'bar',
+      foo2: 'baz'
+    })
+  })
+
+  it('should update validate on setConfig("validate", fn)', () => {
+    const onSubmit = jest.fn()
+    const form = createForm({
+      onSubmit,
+      validate: values => {
+        const errors = {}
+        if (!values.username) {
+          errors.username = 'Required'
+        }
+        return errors
+      }
+    })
+    const username = jest.fn()
+    form.registerField('username', username, { error: true })
+    expect(username).toHaveBeenCalledTimes(1)
+    expect(username.mock.calls[0][0].error).toBe('Required')
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    form.submit()
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    form.setConfig('validate', () => ({}))
+
+    // username is no longer required
+    expect(username).toHaveBeenCalledTimes(2)
+    expect(username.mock.calls[1][0].error).toBe(undefined)
+
+    // form is valid now, so submit should work
+    expect(onSubmit).not.toHaveBeenCalled()
+    form.submit()
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0][0].username).toBe(undefined)
+  })
+
+  it('should replace validateOnBlur on setConfig("validateOnBlur", value)', () => {
+    const validate = jest.fn(values => {
+      const errors = {}
+      if (!values.foo) {
+        errors.foo = 'Required'
+      }
+      return errors
+    })
+    const form = createForm({
+      onSubmit: onSubmitMock,
+      validate,
+      validateOnBlur: false
+    })
+
+    expect(validate).toHaveBeenCalledTimes(1)
+
+    const spy = jest.fn()
+    form.registerField('foo', spy, { error: true })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0][0].error).toBe('Required')
+    expect(validate).toHaveBeenCalledTimes(2)
+
+    form.setConfig('validateOnBlur', true)
+
+    form.focus('foo')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(validate).toHaveBeenCalledTimes(2) // not called on focus
+    form.change('foo', 'typing')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(validate).toHaveBeenCalledTimes(2)
+    form.blur('foo')
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[1][0].error).toBeUndefined()
+    expect(validate).toHaveBeenCalledTimes(3) // called on blur
+
+    form.setConfig('validateOnBlur', false)
+
+    form.focus('foo')
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(validate).toHaveBeenCalledTimes(3) // not called on focus
+    form.change('foo', 'typing something else')
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(validate).toHaveBeenCalledTimes(4) // called on change because we set validateOnBlur=false
+    form.blur('foo')
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(validate).toHaveBeenCalledTimes(4) // not called on blur
+  })
+
+  it('should throw on unknown names', () => {
+    const form = createForm({
+      onSubmit: onSubmitMock
+    })
+    expect(() => {
+      form.setConfig('whatever', false)
+    }).toThrowError('Unrecognised option whatever')
+  })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,8 @@
 export type Subscriber<V> = (value: V) => void
 export type IsEqual = (a: any, b: any) => boolean
-export interface AnyObject { [key: string]: any }
+export interface AnyObject {
+  [key: string]: any
+}
 
 export interface FormSubscription {
   active?: boolean
@@ -154,6 +156,7 @@ export interface FormApi {
   getRegisteredFields: () => string[]
   getState: () => FormState
   mutators: { [key: string]: Function }
+  setConfig: (name: string, value: any) => void
   submit: () => Promise<object | undefined> | undefined
   subscribe: (
     subscriber: FormSubscriber,

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -160,6 +160,7 @@ export type FormApi = {
   registerField: RegisterField,
   reset: () => void,
   resumeValidation: () => void,
+  setConfig: (name: string, value: any) => void,
   submit: () => ?Promise<?Object>,
   subscribe: (
     subscriber: FormSubscriber,


### PR DESCRIPTION
[see final-form/react-final-form#128]

This method lets you update any of the config values after the initial form creation. Updating mutators might be a bit slow, so would be best avoided, but all the other config options should be fine to update.  This will make it fairly simple to fix the issue in react-final-form where props can get out of date.