### PR TITLE
Added a way to set an error on an array of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ field. Useful for subscribing to everything.
 An _à la carte_ list of all the possible things you can subscribe to for a form.
 Useful for subscribing to everything.
 
+### `ARRAY_ERROR: Symbol`
+
+A special `Symbol` key used to return an error for an array of fields.
+
 ### `FORM_ERROR: Symbol`
 
 A special `Symbol` key used to return a whole-form error inside error objects

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -212,6 +212,7 @@ export type Decorator = (form: FormApi) => Unsubscribe
 export function createForm(config: Config): FormApi
 export const fieldSubscriptionItems: string[]
 export const formSubscriptionItems: string[]
+export const ARRAY_ERROR: any
 export const FORM_ERROR: any
 export function getIn(state: object, complexKey: string): any
 export function setIn(state: object, key: string, value: any): object

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 // @flow
-export { default as createForm, FORM_ERROR, version } from './FinalForm'
+export {
+  default as createForm,
+  ARRAY_ERROR,
+  FORM_ERROR,
+  version
+} from './FinalForm'
 export { default as formSubscriptionItems } from './formSubscriptionItems'
 export { default as fieldSubscriptionItems } from './fieldSubscriptionItems'
 export { default as getIn } from './structure/getIn'

--- a/src/publishFieldState.js
+++ b/src/publishFieldState.js
@@ -2,6 +2,7 @@
 import type { InternalFieldState, InternalFormState } from './types'
 import type { FieldState } from './types'
 import getIn from './structure/getIn'
+import { ARRAY_ERROR } from './FinalForm'
 
 /**
  * Converts internal field state to published field state
@@ -21,7 +22,10 @@ const publishFieldState = (
   } = formState
   const { active, blur, change, data, focus, name, touched, visited } = field
   const value = getIn(values, name)
-  const error = getIn(errors, name)
+  let error = getIn(errors, name)
+  if (error && error[ARRAY_ERROR]) {
+    error = error[ARRAY_ERROR]
+  }
   const submitError = submitErrors && getIn((submitErrors: Object), name)
   const initial = initialValues && getIn(initialValues, name)
   const pristine = field.isEqual(initial, value)


### PR DESCRIPTION
You can now set an error for an array of fields.

### Example
```jsx
import { ARRAY_ERROR } from 'final-form'

...

errors.items = []
errors.items[ARRAY_ERROR] = 'You need some items'
```