### PR TITLE
Prefer simple for loop over for-of (it doesnt have to be transpiled)

### DIFF
--- a/src/structure/getIn.js
+++ b/src/structure/getIn.js
@@ -6,7 +6,8 @@ const getIn: GetIn = (state: Object, complexKey: string): any => {
   // Intentionally using iteration rather than recursion
   const path = toPath(complexKey)
   let current: any = state
-  for (let key of path) {
+  for (let i = 0; i < path.length; i++) {
+    const key = path[i]
     if (
       current === undefined ||
       current === null ||


### PR DESCRIPTION
Kinda related to #106. Transpiled for-of depends on `Symbol`

Not only this makes it symbol-independent, it makes also the overall output a little bit smaller:
before - 4419
after - 4336 💵 

