### PR TITLE
Use babel loose mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,9 +3,11 @@
     [
       "env",
       {
+        "loose": true,
         "targets": {
           "node": "8"
-        }
+        },
+        "exclude": ["transform-es2015-typeof-symbol"]
       }
     ],
     "stage-2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,12 @@ export default {
     babel({
       exclude: 'node_modules/**',
       babelrc: false,
-      presets: [['env', { modules: false }], 'stage-2'],
+      presets: [
+        ['env', {
+          modules: false,
+          loose: true,
+          exclude: ['transform-es2015-typeof-symbol'],
+        }], 'stage-2'],
       plugins: ['external-helpers']
     }),
     umd


### PR DESCRIPTION
size comparison:
before - 4419
after - 4242

Usually savings are bigger, I guess u dont use that much of es6 that needs heavier babel transforms.