### PR TITLE
feature: Include field metadata as argument to field validators

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -270,8 +270,11 @@ const createForm = (config: Config): FormApi => {
         const errorOrPromise = validator(
           getIn(state.formState.values, field.name),
           state.formState.values,
-          publishFieldState(state.formState, state.fields[field.name])
+          validator.length === 3
+            ? publishFieldState(state.formState, state.fields[field.name])
+            : undefined
         )
+
         if (errorOrPromise && isPromise(errorOrPromise)) {
           const asyncValidationPromiseKey = nextAsyncValidationKey++
           const promise = errorOrPromise

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -269,7 +269,8 @@ const createForm = (config: Config): FormApi => {
       validators.forEach(validator => {
         const errorOrPromise = validator(
           getIn(state.formState.values, field.name),
-          state.formState.values
+          state.formState.values,
+          publishFieldState(state.formState, state.fields[field.name])
         )
         if (errorOrPromise && isPromise(errorOrPromise)) {
           const asyncValidationPromiseKey = nextAsyncValidationKey++

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -99,7 +99,11 @@ export type FieldSubscriber = Subscriber<FieldState>
 
 export type Unsubscribe = () => void
 
-type FieldValidator = (value: any, allValues: object) => any | Promise<any>
+type FieldValidator = (
+  value: any,
+  allValues: object,
+  meta?: FieldState
+) => any | Promise<any>
 type GetFieldValidator = () => FieldValidator
 
 export interface FieldConfig {

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -103,7 +103,7 @@ export type Unsubscribe = () => void
 export type FieldValidator = (
   value: ?any,
   allValues: Object,
-  meta: FieldState
+  meta: ?FieldState
 ) => ?any | Promise<?any>
 export type GetFieldValidator = () => ?FieldValidator
 

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -102,7 +102,8 @@ export type Unsubscribe = () => void
 
 export type FieldValidator = (
   value: ?any,
-  allValues: Object
+  allValues: Object,
+  meta: FieldState
 ) => ?any | Promise<?any>
 export type GetFieldValidator = () => ?FieldValidator
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->

Fix for #124 

*Important*: Work in progress, opened the PR after spiking through `final-form`, so we can discuss and agree on a final and more refined solution.

### Overview
Pass the field metadata as a third argument to any validator function, enabling validators to also consider the field state (active, dirty, touched, etc...) while validating.

This is specially useful in cases where there is a validator composition since some validations require more context than the value.

Example: imagine an `edit` form sharing the same validations as the `create` form, in this form a `unique` validation for a previously filled field should only check for uniqueness if the value has changed. Validating if it hasn't changed will always fail the validation, and there's no way to tell today since there's no way to access a field's metadata (in this case, `dirty`). 

This will enable more generic fields and validators definition.