### PR TITLE
Added keepDirtyOnReinitialize config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ form.submit() // only submits if all validation passes
 * [Types](#types)
   * [`Config`](#config)
     * [`debug?: DebugFunction`](#debug-debugfunction)
+    * [`keepDirtyOnReinitialize?: boolean`](#keepdirtyonreinitialize-boolean)
     * [`initialValues?: Object`](#initialvalues-object)
     * [`mutators?: { [string]: Mutator }`](#mutators--string-mutator-)
     * [`onSubmit: (values: Object, form: FormApi, callback: ?(errors: ?Object) => void) => ?Object | Promise<?Object> | void`](#onsubmit-values-object-form-formapi-callback-errors-object--void--object--promiseobject--void)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ✅ Opt-in subscriptions - only update on the state you need!
 
-✅ 💥 [**4.1k gzipped**](https://bundlephobia.com/result?p=final-form) 💥
+✅ 💥 [**4.2k gzipped**](https://bundlephobia.com/result?p=final-form) 💥
 
 ---
 
@@ -401,6 +401,10 @@ The current used version of 🏁 Final Form.
 ### `Config`
 
 #### `debug?: DebugFunction`
+
+#### `keepDirtyOnReinitialize?: boolean`
+
+If `true`, only pristine values will be overwritten when `initialize(newValues)` is called. This can be useful for allowing a user to continue to edit a record while the record is being saved asynchronously, and the form is reinitialized to the saved values when the save is successful. Defaults to `false`.
 
 #### `initialValues?: Object`
 

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -27,6 +27,15 @@ import type {
   Unsubscribe
 } from './types'
 import { FORM_ERROR, ARRAY_ERROR } from './constants'
+export const configOptions = [
+  'debug',
+  'initialValues',
+  'keepDirtyOnReinitialize',
+  'mutators',
+  'onSubmit',
+  'validate',
+  'validateOnBlur'
+]
 export const version = '4.6.1'
 
 const tripleEquals: IsEqual = (a: any, b: any): boolean => a === b

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -233,3 +233,4 @@ export const FORM_ERROR: string
 export function getIn(state: object, complexKey: string): any
 export function setIn(state: object, key: string, value: any): object
 export const version: string
+export const configOptions: string[]

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -151,6 +151,15 @@ export interface InternalFormState {
   values: object
 }
 
+type ConfigKey =
+  | 'debug'
+  | 'initialValues'
+  | 'keepDirtyOnReinitialize'
+  | 'mutators'
+  | 'onSubmit'
+  | 'validate'
+  | 'validateOnBlur'
+
 export interface FormApi {
   batch: (fn: () => void) => void
   blur: (name: string) => void
@@ -162,7 +171,7 @@ export interface FormApi {
   getRegisteredFields: () => string[]
   getState: () => FormState
   mutators: { [key: string]: Function }
-  setConfig: (name: string, value: any) => void
+  setConfig: (name: ConfigKey, value: any) => void
   submit: () => Promise<object | undefined> | undefined
   subscribe: (
     subscriber: FormSubscriber,
@@ -203,6 +212,7 @@ export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
 export interface Config {
   debug?: DebugFunction
   initialValues?: object
+  keepDirtyOnReinitialize?: boolean
   mutators?: { [key: string]: Mutator }
   onSubmit: (
     values: object,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // @flow
-export { default as createForm, version } from './FinalForm'
+export { default as createForm, configOptions, version } from './FinalForm'
 export { ARRAY_ERROR, FORM_ERROR } from './constants'
 export { default as formSubscriptionItems } from './formSubscriptionItems'
 export { default as fieldSubscriptionItems } from './fieldSubscriptionItems'

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -27,3 +27,4 @@ declare export var ARRAY_ERROR: string
 declare export function getIn(state: Object, complexKey: string): any
 declare export function setIn(state: Object, key: string, value: any): Object
 declare export var version: string
+declare export var configOptions: string[]

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -154,6 +154,15 @@ export type InternalFormState = {
   values: Object
 }
 
+type ConfigKey =
+  | 'debug'
+  | 'initialValues'
+  | 'keepDirtyOnReinitialize'
+  | 'mutators'
+  | 'onSubmit'
+  | 'validate'
+  | 'validateOnBlur'
+
 export type FormApi = {
   batch: (fn: () => void) => void,
   blur: (name: string) => void,
@@ -169,7 +178,7 @@ export type FormApi = {
   registerField: RegisterField,
   reset: (initialValues?: Object) => void,
   resumeValidation: () => void,
-  setConfig: (name: string, value: any) => void,
+  setConfig: (name: ConfigKey, value: any) => void,
   submit: () => ?Promise<?Object>,
   subscribe: (
     subscriber: FormSubscriber,
@@ -208,6 +217,7 @@ export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
 export type Config = {
   debug?: DebugFunction,
   initialValues?: Object,
+  keepDirtyOnReinitialize?: boolean,
   mutators?: { [string]: Mutator },
   onSubmit: (
     values: Object,


### PR DESCRIPTION
Fixes https://github.com/final-form/react-final-form/issues/246.

Mimics the behavior of [`keepDirtyOnReinitialize`](https://redux-form.com/7.3.0/docs/api/reduxform.md/#-code-keepdirtyonreinitialize-boolean-code-optional-) from Redux Form.