### PR TITLE
Allow form.change() to set values for non-registered fields

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -189,11 +189,9 @@ const createForm = (config: Config): FormApi => {
   }
 
   const changeValue: ChangeValue = (state, name, mutate) => {
-    if (state.fields[name]) {
-      const before = getIn(state.formState.values, name)
-      const after = mutate(before)
-      state.formState.values = setIn(state.formState.values, name, after) || {}
-    }
+    const before = getIn(state.formState.values, name)
+    const after = mutate(before)
+    state.formState.values = setIn(state.formState.values, name, after) || {}
   }
 
   // bind state to mutators
@@ -581,8 +579,8 @@ const createForm = (config: Config): FormApi => {
     },
 
     change: (name: string, value: ?any) => {
-      const { fields, formState } = state
-      if (fields[name] && getIn(formState.values, name) !== value) {
+      const { formState } = state
+      if (getIn(formState.values, name) !== value) {
         changeValue(state, name, () => value)
         if (validateOnBlur) {
           notifyFieldListeners()

--- a/src/FinalForm.mutators.test.js
+++ b/src/FinalForm.mutators.test.js
@@ -44,7 +44,7 @@ describe('FinalForm.mutators', () => {
     expect(formListener.mock.calls[3][0].values.foo).toBeUndefined()
   })
 
-  it('should not allow changeValue to modify a non-registered field', () => {
+  it('should allow changeValue to modify a non-registered field', () => {
     const upper = jest.fn(([name], state, { changeValue }) => {
       changeValue(state, name, value => value && value.toUpperCase())
     })
@@ -63,10 +63,18 @@ describe('FinalForm.mutators', () => {
     form.change('foo', 'bar')
 
     expect(formListener).toHaveBeenCalledTimes(2)
-    expect(formListener.mock.calls[1][0].values.foo).toBe('bar')
+    expect(formListener.mock.calls[1][0].values).toEqual({ foo: 'bar' })
 
     form.mutators.upper('nonexistent.field')
 
-    expect(formListener).toHaveBeenCalledTimes(2)
+    expect(formListener).toHaveBeenCalledTimes(3)
+    expect(formListener.mock.calls[2][0].values).toEqual({
+      foo: 'bar',
+      nonexistant: undefined
+    })
+    expect(Object.keys(formListener.mock.calls[2][0].values)).toEqual([
+      'foo',
+      'nonexistent'
+    ])
   })
 })

--- a/src/FinalForm.subscribing.test.js
+++ b/src/FinalForm.subscribing.test.js
@@ -74,6 +74,30 @@ describe('FinalForm.subscribing', () => {
     expect(fieldSpy.mock.calls[2][0].value).toBe('baz')
   })
 
+  it('should allow form.change() to change any value, not just registered fields', () => {
+    const form = createForm({ onSubmit: onSubmitMock })
+
+    const formSpy = jest.fn()
+    form.subscribe(formSpy, { values: true })
+
+    // called with initial state
+    expect(formSpy).toHaveBeenCalledTimes(1)
+    expect(formSpy.mock.calls[0][0].values.foo).toBeUndefined()
+
+    // update field value
+    form.change('foo', 'bar')
+
+    // form subscriber notified
+    expect(formSpy).toHaveBeenCalledTimes(2)
+    expect(formSpy.mock.calls[1][0].values).toEqual({ foo: 'bar' })
+
+    // update field again, just for good measure
+    form.change('foo', 'baz')
+
+    expect(formSpy).toHaveBeenCalledTimes(3)
+    expect(formSpy.mock.calls[2][0].values).toEqual({ foo: 'baz' })
+  })
+
   it('should not overwrite lastFormState every time a form subscriber is added', () => {
     // this is mostly for code coverage
     const form = createForm({ onSubmit: onSubmitMock })


### PR DESCRIPTION
Fixes https://github.com/final-form/final-form-calculate/issues/15.
Fixes https://github.com/final-form/final-form/issues/102.

I have been thinking about why I originally chose to not allow changes to non-registered fields, and I cannot defend the decision. It makes the library less flexible. This PR lets you now modify field values for fields that are not currently registered.