### PR TITLE
Fix/improve TS declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,9 +20,11 @@ export interface FormSubscription {
   submitFailed?: boolean
   submitting?: boolean
   submitSucceeded?: boolean
+  touched?: boolean
   valid?: boolean
   validating?: boolean
   values?: boolean
+  visited?: boolean
 }
 
 export interface FormState {
@@ -42,9 +44,11 @@ export interface FormState {
   submitFailed: boolean
   submitSucceeded: boolean
   submitting: boolean
+  touched?: { [key: string]: boolean }
   valid: boolean
   validating: boolean
   values: AnyObject
+  visited?: { [key: string]: boolean }
 }
 
 export type FormSubscriber = Subscriber<FormState>
@@ -53,7 +57,7 @@ export interface FieldState {
   active?: boolean
   blur: () => void
   change: (value: any) => void
-  data?: object
+  data?: AnyObject
   dirty?: boolean
   dirtySinceLastSubmit?: boolean
   error?: any
@@ -108,22 +112,19 @@ export type RegisterField = (
   name: string,
   subscriber: FieldSubscriber,
   subscription: FieldSubscription,
-  config: FieldConfig
+  config?: FieldConfig
 ) => Unsubscribe
 
 export interface InternalFieldState {
   active: boolean
   blur: () => void
   change: (value: any) => void
-  data: object
-  error?: any
+  data: AnyObject
   focus: () => void
   isEqual: IsEqual
   lastFieldState?: FieldState
   length?: any
   name: string
-  submitError?: any
-  pristine: boolean
   touched: boolean
   validateFields?: string[]
   validators: {
@@ -171,15 +172,17 @@ export interface FormApi {
   getFieldState: (field: string) => FieldState | undefined
   getRegisteredFields: () => string[]
   getState: () => FormState
-  mutators: { [key: string]: Function }
+  mutators: { [key: string]: (...args: any[]) => any }
+  pauseValidation: () => void
+  registerField: RegisterField
+  reset: (initialValues?: object) => void
+  resumeValidation: () => void
   setConfig: (name: ConfigKey, value: any) => void
   submit: () => Promise<object | undefined> | undefined
   subscribe: (
     subscriber: FormSubscriber,
     subscription: FormSubscription
   ) => Unsubscribe
-  registerField: RegisterField
-  reset: (initialValues?: object) => void
 }
 
 export type DebugFunction = (
@@ -208,7 +211,7 @@ export interface Tools {
   shallowEqual: IsEqual
 }
 
-export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
+export type Mutator = (args: any, state: MutableState, tools: Tools) => any
 
 export interface Config {
   debug?: DebugFunction

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -174,7 +174,7 @@ export type FormApi = {
   getFieldState: (field: string) => ?FieldState,
   getRegisteredFields: () => string[],
   getState: () => FormState,
-  mutators: { [string]: Function },
+  mutators: { [string]: (...args: any[]) => any },
   pauseValidation: () => void,
   registerField: RegisterField,
   reset: (initialValues?: Object) => void,


### PR DESCRIPTION
I noticed a handful of fields missing from the TypeScript declaration, so I updated it to match the Flow one.

In regards to TS, the type `object` isn't ideal, as it doesn't support nested objects correctly. It really needs to be something like `AnyObject`. Furthermore, I would highly suggest typing data/errors/other objects, for example:

```
export interface Data {
  [key: string]: any;
}

export interface Errors {
  [key: string]: string;
}
```

Seems like a bigger task, as Flow would need it to, so I opted not to do it.