### PR TITLE
Fixed validation bug when changing unregistered field

### DIFF
--- a/src/FinalForm.creation.test.js
+++ b/src/FinalForm.creation.test.js
@@ -34,4 +34,10 @@ describe('FinalForm.creation', () => {
     expect(form.getState().pristine).toBe(true)
     expect(form.getState().dirty).toBe(false)
   })
+
+  it('should allow a change to an not-yet-registered field when validation is present', () => {
+    const form = createForm({ onSubmit: onSubmitMock, validate: () => {} })
+    form.registerField('whatever', () => {}, { value: true })
+    form.change('foo', 'bar')
+  })
 })

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -313,12 +313,15 @@ const createForm = (config: Config): FormApi => {
     // pare down field keys to actually validate
     let limitedFieldLevelValidation = false
     if (fieldChanged) {
-      const { validateFields } = fields[fieldChanged]
-      if (validateFields) {
-        limitedFieldLevelValidation = true
-        fieldKeys = validateFields.length
-          ? validateFields.concat(fieldChanged)
-          : [fieldChanged]
+      const changedField = fields[fieldChanged]
+      if (changedField) {
+        const { validateFields } = changedField
+        if (validateFields) {
+          limitedFieldLevelValidation = true
+          fieldKeys = validateFields.length
+            ? validateFields.concat(fieldChanged)
+            : [fieldChanged]
+        }
       }
     }
 


### PR DESCRIPTION
Added a check to make sure a field is registered when inspecting its `validationFields` property.

Fixes https://github.com/final-form/react-final-form/issues/278.