### PR TITLE
Updated reset to delete submitError

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -746,6 +746,7 @@ const createForm = (config: Config): FormApi => {
     reset: (initialValues = state.formState.initialValues) => {
       state.formState.submitFailed = false
       state.formState.submitSucceeded = false
+      delete state.formState.submitError
       delete state.formState.submitErrors
       delete state.formState.lastSubmittedValues
       api.initialize(initialValues || {})


### PR DESCRIPTION
When calling form.reset currently the code resets the submitErrors value but not the submitError value despite setting both when submitting.
