### PR TITLE
do not silently catch errors in promise in onSubmit

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -917,7 +917,7 @@ const createForm = (config: Config): FormApi => {
         if (result && isPromise(result)) {
           // onSubmit is async with a Promise
           notifyFormListeners() // let everyone know we are submitting
-          return result.then(complete, complete)
+          return result.then(complete)
         } else {
           // onSubmit is sync
           complete(result)


### PR DESCRIPTION
Every error in an asynchronous `onSubmit` gets silently ignored at the moment.
Example:
`onSubmit={() => { throw new Error('test') }}` => Throws an error.
`onSubmit={async () => { throw new Error('test') }}` => Nothing happens.

From my understanding, this shouldn’t happen. If there’s a controlled submission error, one should call  something like `return { error: 'test'}` and not `throw`.
We‘re using Sentry to detect any uncaught exception in our production app, thus throwing errors is a critical feature for us.