### PR TITLE
Add TypeScript typings to form data values

### DIFF
--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -1,28 +1,48 @@
 // tslint:disable no-console
 
-import {Config, createForm, AnyObject, Mutator} from './index'
+import { Config, createForm, AnyObject, Mutator } from './index'
 
 const onSubmit: Config['onSubmit'] = (values, callback) => {}
 
-let form = createForm({ initialValues: {foo: 'bar'}, onSubmit })
+let form = createForm({ initialValues: { foo: 'bar' }, onSubmit })
 let formState = form.getState()
+
+type FormData = {
+  foo: string
+  bar: number
+}
+
+form = createForm<FormData>({
+  onSubmit(formData) {
+    console.log(formData.foo as string)
+    console.log(formData.bar as number)
+  }
+})
 
 console.log(formState.active as string, formState.active as undefined)
 console.log(formState.dirty as boolean)
 console.log(formState.dirtyFields as AnyObject, formState.dirtyFields)
 console.log(formState.dirtySinceLastSubmit as boolean)
-console.log(formState.error.foo, formState.error as string, formState.error as boolean)
+console.log(
+  formState.error.foo,
+  formState.error as string,
+  formState.error as boolean
+)
 console.log(formState.errors as AnyObject, formState.errors.foo)
 console.log(formState.initialValues as AnyObject, formState.initialValues.foo)
 console.log(formState.invalid as boolean)
 console.log(formState.pristine as boolean)
-console.log(formState.submitError as string, formState.submitError as object, formState.submitError as undefined)
+console.log(
+  formState.submitError as string,
+  formState.submitError as object,
+  formState.submitError as undefined
+)
 console.log(formState.submitErrors as AnyObject, formState.submitErrors.foo)
 console.log(formState.submitFailed as boolean)
 console.log(formState.submitSucceeded as boolean)
 console.log(formState.submitSucceeded as boolean)
 console.log(formState.submitting as boolean)
-console.log(formState.valid as  boolean)
+console.log(formState.valid as boolean)
 console.log(formState.validating as boolean)
 console.log(formState.values as AnyObject, formState.values.foo)
 
@@ -39,8 +59,7 @@ console.log(formState.dirty as boolean)
 
 // subscription
 form = createForm({ onSubmit, initialValues })
-form.subscribe((state) => {}, { pristine: true })
-
+form.subscribe(state => {}, { pristine: true })
 
 // mutators
 const setValue: Mutator = ([name, newValue], state, { changeValue }) => {

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -36,7 +36,7 @@ console.log(
   formState.submitError as string,
   formState.submitError as object,
   formState.submitError as undefined
-)
+);
 console.log(formState.submitErrors as AnyObject, formState.submitErrors.foo)
 console.log(formState.submitFailed as boolean)
 console.log(formState.submitSucceeded as boolean)

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -14,9 +14,9 @@ type FormData = {
 
 form = createForm<FormData>({
   onSubmit(formData) {
-    console.log(formData.foo as string)
-    console.log(formData.bar as number)
-  }
+    console.log(formData.foo as string);
+    console.log(formData.bar as number);
+  },
 })
 
 console.log(formState.active as string, formState.active as undefined)
@@ -27,7 +27,7 @@ console.log(
   formState.error.foo,
   formState.error as string,
   formState.error as boolean
-)
+);
 console.log(formState.errors as AnyObject, formState.errors.foo)
 console.log(formState.initialValues as AnyObject, formState.initialValues.foo)
 console.log(formState.invalid as boolean)
@@ -59,7 +59,12 @@ console.log(formState.dirty as boolean)
 
 // subscription
 form = createForm({ onSubmit, initialValues })
-form.subscribe(state => {}, { pristine: true })
+form.subscribe(
+  state => {
+    // noop
+  },
+  { pristine: true }
+);
 
 // mutators
 const setValue: Mutator = ([name, newValue], state, { changeValue }) => {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -234,14 +234,14 @@ export interface Tools {
 
 export type Mutator = (args: any, state: MutableState, tools: Tools) => any
 
-export interface Config {
+export interface Config<FormData = object> {
   debug?: DebugFunction
   destroyOnUnregister?: boolean
   initialValues?: object
   keepDirtyOnReinitialize?: boolean
   mutators?: { [key: string]: Mutator }
   onSubmit: (
-    values: object,
+    values: FormData,
     form: FormApi,
     callback?: (errors?: object) => void
   ) => object | Promise<object | undefined> | undefined | void
@@ -251,7 +251,7 @@ export interface Config {
 
 export type Decorator = (form: FormApi) => Unsubscribe
 
-export function createForm(config: Config): FormApi
+export function createForm<FormData>(config: Config<FormData>): FormApi
 export const fieldSubscriptionItems: string[]
 export const formSubscriptionItems: string[]
 export const ARRAY_ERROR: string


### PR DESCRIPTION
`createForm` now have a type parameter.

Sorry for the reformatting on `src/index.d.test.ts`, but it was caused by the precommit hook