### PR TITLE
Change prepublish script to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "nps",
     "test": "nps test",
     "precommit": "lint-staged && npm start validate",
-    "prepublish": "lint-staged && npm start validate"
+    "prepare": "lint-staged && npm start validate"
   },
   "author": "Erik Rasmussen <rasmussenerik@gmail.com> (http://github.com/erikras)",
   "license": "MIT",


### PR DESCRIPTION
`prepublish` runs when doing local `npm install`, `prepare` runs before publishing - seems to me like a better fit here