### PR TITLE
Improvements to the Typescript types around FormData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4023,8 +4023,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4045,14 +4044,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4067,20 +4064,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4197,8 +4191,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4210,7 +4203,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4225,7 +4217,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4233,14 +4224,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4259,7 +4248,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4340,8 +4328,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4353,7 +4340,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4439,8 +4425,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4476,7 +4461,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4496,7 +4480,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4540,14 +4523,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -14,9 +14,9 @@ type FormData = {
 
 form = createForm<FormData>({
   onSubmit(formData) {
-    console.log(formData.foo as string);
-    console.log(formData.bar as number);
-  },
+    console.log(formData.foo as string)
+    console.log(formData.bar as number)
+  }
 })
 
 console.log(formState.active as string, formState.active as undefined)
@@ -27,7 +27,7 @@ console.log(
   formState.error.foo,
   formState.error as string,
   formState.error as boolean
-);
+)
 console.log(formState.errors as AnyObject, formState.errors.foo)
 console.log(formState.initialValues as AnyObject, formState.initialValues.foo)
 console.log(formState.invalid as boolean)
@@ -36,7 +36,7 @@ console.log(
   formState.submitError as string,
   formState.submitError as object,
   formState.submitError as undefined
-);
+)
 console.log(formState.submitErrors as AnyObject, formState.submitErrors.foo)
 console.log(formState.submitFailed as boolean)
 console.log(formState.submitSucceeded as boolean)
@@ -64,7 +64,7 @@ form.subscribe(
     // noop
   },
   { pristine: true }
-);
+)
 
 // mutators
 const setValue: Mutator = ([name, newValue], state, { changeValue }) => {

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -28,6 +28,16 @@ createForm<FormData>({
   }
 })
 
+// validate
+createForm<FormData>({
+  onSubmit,
+  validate(formData) {
+    console.log(formData.foo as string)
+    console.log(formData.bar as number)
+    return formData
+  }
+})
+
 // submit
 let submitPromise = createForm<FormData>({ onSubmit }).submit()
 

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -19,6 +19,15 @@ form = createForm<FormData>({
   }
 })
 
+// initialValues
+form = createForm<FormData>({
+  initialValues: { foo: 'baz', bar: 0 },
+  onSubmit(formData) {
+    console.log(formData.foo as string)
+    console.log(formData.bar as number)
+  }
+})
+
 // submit
 let submitPromise = createForm<FormData>({ onSubmit }).submit()
 

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -19,6 +19,18 @@ form = createForm<FormData>({
   }
 })
 
+// submit
+let submitPromise = createForm<FormData>({ onSubmit }).submit()
+
+if (submitPromise) {
+  submitPromise.then(formData => {
+    if (formData) {
+      console.log(formData.foo as string)
+      console.log(formData.bar as number)
+    }
+  })
+}
+
 console.log(formState.active as string, formState.active as undefined)
 console.log(formState.dirty as boolean)
 console.log(formState.dirtyFields as AnyObject, formState.dirtyFields)

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -38,6 +38,13 @@ createForm<FormData>({
   }
 })
 
+createForm<FormData>({
+  onSubmit,
+  validate() {
+    return undefined
+  }
+})
+
 // submit
 let submitPromise = createForm<FormData>({ onSubmit }).submit()
 

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -12,7 +12,7 @@ type FormData = {
   bar: number
 }
 
-form = createForm<FormData>({
+createForm<FormData>({
   onSubmit(formData) {
     console.log(formData.foo as string)
     console.log(formData.bar as number)
@@ -56,6 +56,13 @@ if (submitPromise) {
     }
   })
 }
+
+// initialize
+createForm<FormData>({ onSubmit }).initialize({ foo: 'baz', bar: 11 })
+createForm<FormData>({ onSubmit }).initialize(formData => ({
+  ...formData,
+  bar: 12
+}))
 
 console.log(formState.active as string, formState.active as undefined)
 console.log(formState.dirty as boolean)

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -20,7 +20,7 @@ form = createForm<FormData>({
 })
 
 // initialValues
-form = createForm<FormData>({
+createForm<FormData>({
   initialValues: { foo: 'baz', bar: 0 },
   onSubmit(formData) {
     console.log(formData.foo as string)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -254,7 +254,7 @@ export interface Config<FormData = object> {
     form: FormApi,
     callback?: (errors?: object) => void
   ) => object | Promise<object | undefined> | undefined | void
-  validate?: (values: object) => object | Promise<object>
+  validate?: (values: FormData) => object | Promise<object>
   validateOnBlur?: boolean
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -184,7 +184,7 @@ type ConfigKey =
   | 'validate'
   | 'validateOnBlur'
 
-export interface FormApi {
+export interface FormApi<FormData = object> {
   batch: (fn: () => void) => void
   blur: (name: string) => void
   change: (name: string, value?: any) => void
@@ -200,7 +200,7 @@ export interface FormApi {
   reset: (initialValues?: object) => void
   resumeValidation: () => void
   setConfig: (name: ConfigKey, value: any) => void
-  submit: () => Promise<object | undefined> | undefined
+  submit: () => Promise<FormData | undefined> | undefined
   subscribe: (
     subscriber: FormSubscriber,
     subscription: FormSubscription
@@ -260,7 +260,9 @@ export interface Config<FormData = object> {
 
 export type Decorator = (form: FormApi) => Unsubscribe
 
-export function createForm<FormData>(config: Config<FormData>): FormApi
+export function createForm<FormData>(
+  config: Config<FormData>
+): FormApi<FormData>
 export const fieldSubscriptionItems: string[]
 export const formSubscriptionItems: string[]
 export const ARRAY_ERROR: string

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -246,7 +246,7 @@ export type Mutator = (args: any, state: MutableState, tools: Tools) => any
 export interface Config<FormData = object> {
   debug?: DebugFunction
   destroyOnUnregister?: boolean
-  initialValues?: object
+  initialValues?: FormData
   keepDirtyOnReinitialize?: boolean
   mutators?: { [key: string]: Mutator }
   onSubmit: (

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -191,7 +191,7 @@ export interface FormApi<FormData = object> {
   blur: (name: string) => void
   change: (name: string, value?: any) => void
   focus: (name: string) => void
-  initialize: (data: Object | ((values: Object) => Object)) => void
+  initialize: (data: FormData | ((values: FormData) => FormData)) => void
   isValidationPaused: () => boolean
   getFieldState: (field: string) => FieldState | undefined
   getRegisteredFields: () => string[]

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ export type IsEqual = (a: any, b: any) => boolean
 export interface AnyObject {
   [key: string]: any
 }
+export interface ValidationErrors extends AnyObject {}
 
 export interface FormSubscription {
   active?: boolean
@@ -37,7 +38,7 @@ export interface FormState {
   dirtyFields: { [key: string]: boolean }
   dirtySinceLastSubmit: boolean
   error: any
-  errors: AnyObject
+  errors: ValidationErrors
   hasSubmitErrors: boolean
   hasValidationErrors: boolean
   initialValues: AnyObject
@@ -160,7 +161,7 @@ export interface InternalFormState {
   active?: string
   dirtySinceLastSubmit: boolean
   error?: any
-  errors: object
+  errors: ValidationErrors
   initialValues?: object
   lastSubmittedValues?: object
   pristine: boolean
@@ -254,7 +255,7 @@ export interface Config<FormData = object> {
     form: FormApi,
     callback?: (errors?: object) => void
   ) => object | Promise<object | undefined> | undefined | void
-  validate?: (values: FormData) => object | Promise<object>
+  validate?: (values: FormData) => ValidationErrors | Promise<ValidationErrors>
   validateOnBlur?: boolean
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export interface AnyObject {
   [key: string]: any
 }
 export interface ValidationErrors extends AnyObject {}
+export interface SubmissionErrors extends AnyObject {}
 
 export interface FormSubscription {
   active?: boolean
@@ -253,8 +254,12 @@ export interface Config<FormData = object> {
   onSubmit: (
     values: FormData,
     form: FormApi,
-    callback?: (errors?: object) => void
-  ) => object | Promise<object | undefined> | undefined | void
+    callback?: (errors?: SubmissionErrors) => void
+  ) =>
+    | SubmissionErrors
+    | Promise<SubmissionErrors | undefined>
+    | undefined
+    | void
   validate?: (values: FormData) => ValidationErrors | Promise<ValidationErrors>
   validateOnBlur?: boolean
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -260,7 +260,9 @@ export interface Config<FormData = object> {
     | Promise<SubmissionErrors | undefined>
     | undefined
     | void
-  validate?: (values: FormData) => ValidationErrors | Promise<ValidationErrors>
+  validate?: (
+    values: FormData
+  ) => ValidationErrors | Promise<ValidationErrors> | undefined
   validateOnBlur?: boolean
 }
 


### PR DESCRIPTION
We have been using Final Form in a React project for about a year now. It's been overall great, but the lack of valid types around form data has been a bit annoying. 

For example:

```tsx
<Form
  initialValues={{ name: "Billy" }}
  onSubmit={formData => {
    console.log(formData.name) // Error
  }}
  validate={formData => {
    console.log(formData.name) // Error
  }}
>
 ...
</Form>
```

This PR contains some initial changes to the definitions required to improve the situation. A subsequent PR to react-final-form will be necessary to solve the problem entirely. I would like to eventually take the `react-apollo-hooks` approach and use no-op inheritance to do this:

```tsx
class PersonForm extends Form<{ name: string }> {}

<PersonForm
  initialValues={{ name: "Billy" }}
  onSubmit={formData => {
    console.log(formData.name) // Okay 
  }}
  validate={formData => {
    console.log(formData.name) // Great!
  }}
>
 ...
</PersonForm>
```


<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
