### PR TITLE
improve performance of setIn

### DIFF
--- a/src/structure/setIn.js
+++ b/src/structure/setIn.js
@@ -44,8 +44,8 @@ const setInRecursor = (
       value,
       destroyArrays
     )
-    const numKeys = Object.keys(current).length
     if (result === undefined) {
+      const numKeys = Object.keys(current).length
       if (current[key] === undefined && numKeys === 0) {
         // object was already empty
         return undefined


### PR DESCRIPTION
`Object.keys` is called only when necessary.

I go from 3.57s to 2.93s by making a change on a huge form. (related to https://github.com/final-form/final-form/issues/193)

The remaining slow part is:
https://github.com/final-form/final-form/blob/f02fd2699e4cb056b9d55882c1ac0d80e77ef9e7/src/structure/setIn.js#L66-L69