### PR TITLE
Improve mount/unmount performance

### DIFF
--- a/src/structure/toPath.js
+++ b/src/structure/toPath.js
@@ -6,7 +6,7 @@ const toPath = (key: string): string[] => {
   if (typeof key !== 'string') {
     throw new Error('toPath() expects a string')
   }
-  return key.split(/[.[\]]+/).filter(Boolean)
+  return key.match(/[^[\].]+/g) || []
 }
 
 export default toPath


### PR DESCRIPTION
Hi!
We use final-form in our product to display    a large number of fields (over 500). When we switch between forms, we wait a very long time when the form is replaced.
I found out that performance is greatly increased if you use a more efficient regexp in the toPath method.