### PR TITLE
 Strongly typed form values for Flow and Typescript

### DIFF
--- a/src/FinalForm.subscribing.test.js
+++ b/src/FinalForm.subscribing.test.js
@@ -936,6 +936,7 @@ describe('FinalForm.subscribing', () => {
     const foo = jest.fn(({ value }) => {
       if (value === 42) {
         unregisterBar()
+        form.reset()
       }
     })
     const bar = jest.fn()
@@ -952,7 +953,7 @@ describe('FinalForm.subscribing', () => {
     expect(bar).toHaveBeenCalledTimes(2)
 
     form.change('foo', 42)
-    expect(foo).toHaveBeenCalledTimes(2)
+    expect(foo).toHaveBeenCalledTimes(3)
     expect(bar).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/filterFormState.js
+++ b/src/filterFormState.js
@@ -1,21 +1,20 @@
 // @flow
 import formSubscriptionItems from './formSubscriptionItems'
 import subscriptionFilter from './subscriptionFilter'
-import type { StateFilter } from './FinalForm'
-import type { FormState, FormSubscription } from './types'
+import type { FormState, FormSubscription, FormValuesShape } from './types'
 
 const shallowEqualKeys = ['touched', 'visited']
 
 /**
  * Filters items in a FormState based on a FormSubscription
  */
-const filterFormState: StateFilter<FormState> = (
-  state: FormState,
-  previousState: ?FormState,
+export default function filterFormState<FormValues: FormValuesShape>(
+  state: FormState<FormValues>,
+  previousState: ?FormState<FormValues>,
   subscription: FormSubscription,
   force: boolean
-): ?FormState => {
-  const result: FormState = {}
+): ?FormState<FormValues> {
+  const result: FormState<FormValues> = {}
   const different =
     subscriptionFilter(
       result,
@@ -27,5 +26,3 @@ const filterFormState: StateFilter<FormState> = (
     ) || !previousState
   return different || force ? result : undefined
 }
-
-export default filterFormState

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -4,15 +4,15 @@ import { Config, createForm, AnyObject, Mutator } from './index'
 
 const onSubmit: Config['onSubmit'] = (values, callback) => {}
 
-let form = createForm({ initialValues: { foo: 'bar' }, onSubmit })
-let formState = form.getState()
-
-type FormData = {
+type FormValues = {
   foo: string
-  bar: number
+  bar?: number
 }
 
-createForm<FormData>({
+let form = createForm<FormValues>({ initialValues: { foo: 'bar' }, onSubmit })
+let formState = form.getState()
+
+createForm<FormValues>({
   onSubmit(formData) {
     console.log(formData.foo as string)
     console.log(formData.bar as number)
@@ -20,7 +20,7 @@ createForm<FormData>({
 })
 
 // initialValues
-createForm<FormData>({
+createForm<FormValues>({
   initialValues: { foo: 'baz', bar: 0 },
   onSubmit(formData) {
     console.log(formData.foo as string)
@@ -29,7 +29,7 @@ createForm<FormData>({
 })
 
 // validate
-createForm<FormData>({
+createForm<FormValues>({
   onSubmit,
   validate(formData) {
     console.log(formData.foo as string)
@@ -38,7 +38,7 @@ createForm<FormData>({
   }
 })
 
-createForm<FormData>({
+createForm<FormValues>({
   onSubmit,
   validate() {
     return undefined
@@ -46,7 +46,7 @@ createForm<FormData>({
 })
 
 // submit
-let submitPromise = createForm<FormData>({ onSubmit }).submit()
+let submitPromise = createForm<FormValues>({ onSubmit }).submit()
 
 if (submitPromise) {
   submitPromise.then(formData => {
@@ -58,8 +58,8 @@ if (submitPromise) {
 }
 
 // initialize
-createForm<FormData>({ onSubmit }).initialize({ foo: 'baz', bar: 11 })
-createForm<FormData>({ onSubmit }).initialize(formData => ({
+createForm<FormValues>({ onSubmit }).initialize({ foo: 'baz', bar: 11 })
+createForm<FormValues>({ onSubmit }).initialize(formData => ({
   ...formData,
   bar: 12
 }))
@@ -91,19 +91,24 @@ console.log(formState.valid as boolean)
 console.log(formState.validating as boolean)
 console.log(formState.values as AnyObject, formState.values.foo)
 
-const initialValues: Config['initialValues'] = {
+type FormValues2 = {
+  a: string
+  b: boolean
+  c: number
+}
+const initialValues: Config<FormValues2>['initialValues'] = {
   a: 'a',
   b: true,
   c: 1
 }
 
-form = createForm({ onSubmit, initialValues })
+let form2 = createForm<FormValues2>({ onSubmit, initialValues })
 formState = form.getState()
 console.log(formState.pristine as boolean)
 console.log(formState.dirty as boolean)
 
 // subscription
-form = createForm({ onSubmit, initialValues })
+form2 = createForm<FormValues2>({ onSubmit, initialValues })
 form.subscribe(
   state => {
     // noop
@@ -117,7 +122,7 @@ const setValue: Mutator = ([name, newValue], state, { changeValue }) => {
 }
 
 type Mutators = { setValue: (name: string, value: string) => void }
-form = createForm({
+form2 = createForm<FormValues2>({
   mutators: { setValue },
   onSubmit
 })

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -1,16 +1,17 @@
 // tslint:disable no-console
+import { AnyObject, Config, createForm, Mutator } from './index'
 
-import { Config, createForm, AnyObject, Mutator } from './index'
+const onSubmit: Config['onSubmit'] = (values, callback) => {
+  console.info('submitted', values)
+}
 
-const onSubmit: Config['onSubmit'] = (values, callback) => {}
-
-type FormValues = {
+interface FormValues {
   foo: string
   bar?: number
 }
 
-let form = createForm<FormValues>({ initialValues: { foo: 'bar' }, onSubmit })
-let formState = form.getState()
+const form = createForm<FormValues>({ initialValues: { foo: 'bar' }, onSubmit })
+const formState = form.getState()
 
 createForm<FormValues>({
   onSubmit(formData) {
@@ -46,7 +47,7 @@ createForm<FormValues>({
 })
 
 // submit
-let submitPromise = createForm<FormValues>({ onSubmit }).submit()
+const submitPromise = createForm<FormValues>({ onSubmit }).submit()
 
 if (submitPromise) {
   submitPromise.then(formData => {
@@ -91,7 +92,7 @@ console.log(formState.valid as boolean)
 console.log(formState.validating as boolean)
 console.log(formState.values as AnyObject, formState.values.foo)
 
-type FormValues2 = {
+interface FormValues2 {
   a: string
   b: boolean
   c: number
@@ -103,13 +104,13 @@ const initialValues: Config<FormValues2>['initialValues'] = {
 }
 
 let form2 = createForm<FormValues2>({ onSubmit, initialValues })
-formState = form.getState()
+const formState2 = form2.getState()
 console.log(formState.pristine as boolean)
 console.log(formState.dirty as boolean)
 
 // subscription
 form2 = createForm<FormValues2>({ onSubmit, initialValues })
-form.subscribe(
+form2.subscribe(
   state => {
     // noop
   },
@@ -121,7 +122,9 @@ const setValue: Mutator = ([name, newValue], state, { changeValue }) => {
   changeValue(state, name, value => newValue)
 }
 
-type Mutators = { setValue: (name: string, value: string) => void }
+type Mutators = {
+  setValue: (name: string, value: string) => void
+}
 form2 = createForm<FormValues2>({
   mutators: { setValue },
   onSubmit

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -1,13 +1,12 @@
 // tslint:disable no-console
 import { AnyObject, Config, createForm, Mutator } from './index'
 
-const onSubmit: Config['onSubmit'] = (values, callback) => {
-  console.info('submitted', values)
-}
-
 interface FormValues {
   foo: string
   bar?: number
+}
+const onSubmit = (values: FormValues) => {
+  console.info('submitted', values)
 }
 
 const form = createForm<FormValues>({ initialValues: { foo: 'bar' }, onSubmit })
@@ -103,13 +102,16 @@ const initialValues: Config<FormValues2>['initialValues'] = {
   c: 1
 }
 
-let form2 = createForm<FormValues2>({ onSubmit, initialValues })
+const onSubmit2 = (values: FormValues2) => {
+  console.info('submitted', values)
+}
+let form2 = createForm<FormValues2>({ onSubmit: onSubmit2, initialValues })
 const formState2 = form2.getState()
 console.log(formState.pristine as boolean)
 console.log(formState.dirty as boolean)
 
 // subscription
-form2 = createForm<FormValues2>({ onSubmit, initialValues })
+form2 = createForm<FormValues2>({ onSubmit: onSubmit2, initialValues })
 form2.subscribe(
   state => {
     // noop
@@ -127,7 +129,7 @@ type Mutators = {
 }
 form2 = createForm<FormValues2>({
   mutators: { setValue },
-  onSubmit
+  onSubmit: onSubmit2
 })
 
 // Get form.mutators cast to Mutators

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -107,8 +107,8 @@ const onSubmit2 = (values: FormValues2) => {
 }
 let form2 = createForm<FormValues2>({ onSubmit: onSubmit2, initialValues })
 const formState2 = form2.getState()
-console.log(formState.pristine as boolean)
-console.log(formState.dirty as boolean)
+console.log(formState2.pristine as boolean)
+console.log(formState2.dirty as boolean)
 
 // subscription
 form2 = createForm<FormValues2>({ onSubmit: onSubmit2, initialValues })
@@ -133,5 +133,5 @@ form2 = createForm<FormValues2>({
 })
 
 // Get form.mutators cast to Mutators
-const mutators: Mutators = form.mutators as Mutators
+const mutators: Mutators = form2.mutators as Mutators
 mutators.setValue('firstName', 'Kevin')

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,7 @@ export interface FormSubscription {
   visited?: boolean
 }
 
-export interface FormState {
+export interface FormState<FormValues> {
   // by default: all values are subscribed. if subscription is specified, some values may be undefined
   active: undefined | string
   dirty: boolean
@@ -42,7 +42,7 @@ export interface FormState {
   errors: ValidationErrors
   hasSubmitErrors: boolean
   hasValidationErrors: boolean
-  initialValues: AnyObject
+  initialValues: FormValues
   invalid: boolean
   modified?: { [key: string]: boolean }
   pristine: boolean
@@ -54,11 +54,11 @@ export interface FormState {
   touched?: { [key: string]: boolean }
   valid: boolean
   validating: boolean
-  values: AnyObject
+  values: FormValues
   visited?: { [key: string]: boolean }
 }
 
-export type FormSubscriber = Subscriber<FormState>
+export type FormSubscriber<FormValues> = Subscriber<FormState<FormValues>>
 
 export interface FieldState {
   active?: boolean
@@ -180,73 +180,77 @@ export interface InternalFormState {
 
 type ConfigKey = keyof Config
 
-export interface FormApi<FormData = object> {
+export interface FormApi<FormValues = object> {
   batch: (fn: () => void) => void
   blur: (name: string) => void
   change: (name: string, value?: any) => void
   focus: (name: string) => void
-  initialize: (data: FormData | ((values: FormData) => FormData)) => void
+  initialize: (data: FormValues | ((values: FormValues) => FormValues)) => void
   isValidationPaused: () => boolean
   getFieldState: (field: string) => FieldState | undefined
   getRegisteredFields: () => string[]
-  getState: () => FormState
+  getState: () => FormState<FormValues>
   mutators: { [key: string]: (...args: any[]) => any }
   pauseValidation: () => void
   registerField: RegisterField
   reset: (initialValues?: object) => void
   resumeValidation: () => void
   setConfig: (name: ConfigKey, value: any) => void
-  submit: () => Promise<FormData | undefined> | undefined
+  submit: () => Promise<FormValues | undefined> | undefined
   subscribe: (
-    subscriber: FormSubscriber,
+    subscriber: FormSubscriber<FormValues>,
     subscription: FormSubscription
   ) => Unsubscribe
 }
 
-export type DebugFunction = (
-  state: FormState,
+export type DebugFunction<FormValues> = (
+  state: FormState<FormValues>,
   fieldStates: { [key: string]: FieldState }
 ) => void
 
-export interface MutableState {
+export interface MutableState<FormValues> {
   fieldSubscribers: { [key: string]: Subscribers<FieldState> }
   fields: {
     [key: string]: InternalFieldState
   }
   formState: InternalFormState
-  lastFormState?: FormState
+  lastFormState?: FormState<FormValues>
 }
 
 export type GetIn = (state: object, complexKey: string) => any
 export type SetIn = (state: object, key: string, value: any) => object
-export type ChangeValue = (
-  state: MutableState,
+export type ChangeValue<FormValues = object> = (
+  state: MutableState<FormValues>,
   name: string,
   mutate: (value: any) => any
 ) => void
-export type RenameField = (
-  state: MutableState,
+export type RenameField<FormValues = object> = (
+  state: MutableState<FormValues>,
   from: string,
   to: string
 ) => void
-export interface Tools {
-  changeValue: ChangeValue
+export interface Tools<FormValues> {
+  changeValue: ChangeValue<FormValues>
   getIn: GetIn
-  renameField: RenameField
+  renameField: RenameField<FormValues>
   setIn: SetIn
   shallowEqual: IsEqual
 }
 
-export type Mutator = (args: any, state: MutableState, tools: Tools) => any
+export type Mutator<FormValues = object> = (
+  args: any,
+  state: MutableState<FormValues>,
+  tools: Tools<FormValues>
+) => any
 
-export interface Config<FormData = object> {
-  debug?: DebugFunction
+export interface Config<FormValues = object> {
+  debug?: DebugFunction<FormValues>
   destroyOnUnregister?: boolean
-  initialValues?: FormData
+  initialValues?: FormValues
   keepDirtyOnReinitialize?: boolean
   mutators?: { [key: string]: Mutator }
   onSubmit: (
-    values: FormData,
+    values: FormValues,
     form: FormApi,
     callback?: (errors?: SubmissionErrors) => void
   ) =>
@@ -255,16 +259,16 @@ export interface Config<FormData = object> {
     | undefined
     | void
   validate?: (
-    values: FormData
+    values: FormValues
   ) => ValidationErrors | Promise<ValidationErrors> | undefined
   validateOnBlur?: boolean
 }
 
 export type Decorator = (form: FormApi) => Unsubscribe
 
-export function createForm<FormData>(
-  config: Config<FormData>
-): FormApi<FormData>
+export function createForm<FormValues>(
+  config: Config<FormValues>
+): FormApi<FormValues>
 export const fieldSubscriptionItems: string[]
 export const formSubscriptionItems: string[]
 export const ARRAY_ERROR: string

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -251,7 +251,7 @@ export interface Config<FormValues = object> {
   mutators?: { [key: string]: Mutator }
   onSubmit: (
     values: FormValues,
-    form: FormApi,
+    form?: FormApi<FormValues>,
     callback?: (errors?: SubmissionErrors) => void
   ) =>
     | SubmissionErrors
@@ -264,7 +264,9 @@ export interface Config<FormValues = object> {
   validateOnBlur?: boolean
 }
 
-export type Decorator = (form: FormApi) => Unsubscribe
+export type Decorator<FormValues = object> = (
+  form: FormApi<FormValues>
+) => Unsubscribe
 
 export function createForm<FormValues>(
   config: Config<FormValues>

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import type { Config, ConfigKey, FormApi } from './types'
+import type { Config, ConfigKey, FormApi, FormValuesShape } from './types'
 
 export type {
   Config,
@@ -11,6 +11,7 @@ export type {
   FormApi,
   FormState,
   FormSubscription,
+  FormValuesShape,
   GetFieldValidator,
   MutableState,
   Mutator,
@@ -19,7 +20,9 @@ export type {
   Unsubscribe
 } from './types'
 
-declare export function createForm(config: Config): FormApi
+declare export function createForm<FormValues: FormValuesShape>(
+  config: Config<FormValues>
+): FormApi<FormValues>
 declare export var fieldSubscriptionItems: string[]
 declare export var formSubscriptionItems: string[]
 declare export var FORM_ERROR: string

--- a/src/publishFieldState.js
+++ b/src/publishFieldState.js
@@ -1,16 +1,16 @@
 // @flow
 import type { InternalFieldState, InternalFormState } from './types'
-import type { FieldState } from './types'
+import type { FieldState, FormValuesShape } from './types'
 import getIn from './structure/getIn'
 import { ARRAY_ERROR } from './constants'
 
 /**
  * Converts internal field state to published field state
  */
-const publishFieldState = (
-  formState: InternalFormState,
+function publishFieldState<FormValues: FormValuesShape>(
+  formState: InternalFormState<FormValues>,
   field: InternalFieldState
-): FieldState => {
+): FieldState {
   const {
     errors,
     initialValues,

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -3,6 +3,10 @@ export type Subscription = { [string]: boolean }
 export type Subscriber<V> = (value: V) => void
 export type IsEqual = (a: any, b: any) => boolean
 
+export type FormValuesShape = {
+  [string]: any
+}
+
 export type FormSubscription = {
   active?: boolean,
   dirty?: boolean,
@@ -28,7 +32,7 @@ export type FormSubscription = {
   visited?: boolean
 }
 
-export type FormState = {
+export type FormState<FormValues: FormValuesShape> = {
   // all values are optional because they must be subscribed to
   active?: string,
   dirty?: boolean,
@@ -38,7 +42,7 @@ export type FormState = {
   errors?: Object,
   hasSubmitErrors?: boolean,
   hasValidationErrors?: boolean,
-  initialValues?: Object,
+  initialValues?: FormValues,
   invalid?: boolean,
   modified?: { [string]: boolean },
   pristine?: boolean,
@@ -50,11 +54,13 @@ export type FormState = {
   touched?: { [string]: boolean },
   valid?: boolean,
   validating?: boolean,
-  values?: Object,
+  values?: FormValues,
   visited?: { [string]: boolean }
 }
 
-export type FormSubscriber = Subscriber<FormState>
+export type FormSubscriber<FormValues: FormValuesShape> = Subscriber<
+  FormState<FormValues>
+>
 
 export type FieldState = {
   active?: boolean,
@@ -158,7 +164,7 @@ export type InternalFieldState = {
   visited: boolean
 }
 
-export type InternalFormState = {
+export type InternalFormState<FormValues: FormValuesShape> = {
   active?: string,
   dirtySinceLastSubmit: boolean,
   error?: any,
@@ -173,7 +179,7 @@ export type InternalFormState = {
   submitting: boolean,
   valid: boolean,
   validating: number,
-  values: Object
+  values: FormValues
 }
 
 export type ConfigKey =
@@ -186,7 +192,7 @@ export type ConfigKey =
   | 'validate'
   | 'validateOnBlur'
 
-export type FormApi = {
+export type FormApi<FormValues: FormValuesShape> = {
   batch: (fn: () => void) => void,
   blur: (name: string) => void,
   change: (name: string, value: ?any) => void,
@@ -195,7 +201,7 @@ export type FormApi = {
   isValidationPaused: () => boolean,
   getFieldState: (field: string) => ?FieldState,
   getRegisteredFields: () => string[],
-  getState: () => FormState,
+  getState: () => FormState<FormValues>,
   mutators: { [string]: (...args: any[]) => any },
   pauseValidation: () => void,
   registerField: RegisterField,
@@ -204,23 +210,23 @@ export type FormApi = {
   setConfig: (name: ConfigKey, value: any) => void,
   submit: () => ?Promise<?Object>,
   subscribe: (
-    subscriber: FormSubscriber,
+    subscriber: FormSubscriber<FormValues>,
     subscription: FormSubscription
   ) => Unsubscribe
 }
 
-export type DebugFunction = (
-  state: FormState,
+export type DebugFunction<FormValues: FormValuesShape> = (
+  state: FormState<FormValues>,
   fieldStates: { [string]: FieldState }
 ) => void
 
-export type MutableState = {
+export type MutableState<FormValues: FormValuesShape> = {
   fieldSubscribers: { [string]: Subscribers<FieldState> },
   fields: {
     [string]: InternalFieldState
   },
-  formState: InternalFormState,
-  lastFormState?: FormState
+  formState: InternalFormState<FormValues>,
+  lastFormState?: FormState<FormValues>
 }
 
 export type GetIn = (state: Object, complexKey: string) => any
@@ -230,39 +236,45 @@ export type SetIn = (
   value: any,
   destroyArrays?: boolean
 ) => Object
-export type ChangeValue = (
-  state: MutableState,
+export type ChangeValue<FormValues: FormValuesShape> = (
+  state: MutableState<FormValues>,
   name: string,
   mutate: (value: any) => any
 ) => void
-export type RenameField = (
-  state: MutableState,
+export type RenameField<FormValues: FormValuesShape> = (
+  state: MutableState<FormValues>,
   from: string,
   to: string
 ) => void
-export type Tools = {
-  changeValue: ChangeValue,
+export type Tools<FormValues: FormValuesShape> = {
+  changeValue: ChangeValue<FormValues>,
   getIn: GetIn,
-  renameField: RenameField,
+  renameField: RenameField<FormValues>,
   setIn: SetIn,
   shallowEqual: IsEqual
 }
 
-export type Mutator = (args: any[], state: MutableState, tools: Tools) => any
+export type Mutator<FormValues: FormValuesShape> = (
+  args: any[],
+  state: MutableState<FormValues>,
+  tools: Tools<FormValues>
+) => any
 
-export type Config = {
-  debug?: DebugFunction,
+export type Config<FormValues: FormValuesShape> = {
+  debug?: DebugFunction<FormValues>,
   destroyOnUnregister?: boolean,
   initialValues?: Object,
   keepDirtyOnReinitialize?: boolean,
-  mutators?: { [string]: Mutator },
+  mutators?: { [string]: Mutator<FormValues> },
   onSubmit: (
     values: Object,
-    form: FormApi,
+    form: FormApi<FormValues>,
     callback: ?(errors: ?Object) => ?Object
   ) => ?Object | Promise<?Object> | void,
   validate?: (values: Object) => Object | Promise<Object>,
   validateOnBlur?: boolean
 }
 
-export type Decorator = (form: FormApi) => Unsubscribe
+export type Decorator<FormValues: FormValuesShape> = (
+  form: FormApi<FormValues>
+) => Unsubscribe

--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,13 @@
   "defaultSeverity": "error",
   "extends": ["tslint:recommended"],
   "jsRules": {},
-  "rules": {},
+  "rules": {
+    "quotemark": [true, "single", "avoid-escape", "jsx-double"],
+    "semicolon": [true, "never"],
+    "trailing-comma": [true, "never"],
+    "interface-name": [true, "never-prefix"],
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "interface-over-type-literal": false
+  },
   "rulesDirectory": []
 }


### PR DESCRIPTION
People have been attempting to get close to this for a while now.

It's my understanding that there's no good way of typing the actual fields. What this provides is strong typing for the `values` and `initialValues` when using Final Form.