### PR TITLE
Update types.js.flow

### DIFF
--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -263,11 +263,11 @@ export type Mutator<FormValues: FormValuesShape> = (
 export type Config<FormValues: FormValuesShape> = {
   debug?: DebugFunction<FormValues>,
   destroyOnUnregister?: boolean,
-  initialValues?: Object,
+  initialValues?: FormValues,
   keepDirtyOnReinitialize?: boolean,
   mutators?: { [string]: Mutator<FormValues> },
   onSubmit: (
-    values: Object,
+    values: FormValues,
     form: FormApi<FormValues>,
     callback: ?(errors: ?Object) => ?Object
   ) => ?Object | Promise<?Object> | void,


### PR DESCRIPTION
It feels like `initialValues` and `onSubmit` should receive the type as well.
