### PR TITLE
Added a validating key  to fieldState, will be true when promise returned from a field validate function,useful for individual file uploads in form.

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,15 +88,15 @@
   "bundlesize": [
     {
       "path": "dist/final-form.umd.min.js",
-      "maxSize": "4.9kB"
+      "maxSize": "4.94kB"
     },
     {
       "path": "dist/final-form.es.js",
-      "maxSize": "8.5kB"
+      "maxSize": "8.52kB"
     },
     {
       "path": "dist/final-form.cjs.js",
-      "maxSize": "8.5kB"
+      "maxSize": "8.65kB"
     }
   ],
   "dependencies": {

--- a/src/fieldSubscriptionItems.js
+++ b/src/fieldSubscriptionItems.js
@@ -17,5 +17,6 @@ export default [
   'touched',
   'valid',
   'value',
-  'visited'
+  'visited',
+  'validating'
 ]

--- a/src/publishFieldState.js
+++ b/src/publishFieldState.js
@@ -19,7 +19,8 @@ function publishFieldState<FormValues: FormValuesShape>(
     submitFailed,
     submitSucceeded,
     submitting,
-    values
+    values,
+    fieldsWithPromisePending
   } = formState
   const {
     active,
@@ -45,6 +46,7 @@ function publishFieldState<FormValues: FormValuesShape>(
     !field.isEqual(getIn(lastSubmittedValues, name), value)
   )
   const valid = !error && !submitError
+  const validating = getIn(fieldsWithPromisePending, name)
   return {
     active,
     blur,
@@ -67,7 +69,8 @@ function publishFieldState<FormValues: FormValuesShape>(
     touched,
     valid,
     value,
-    visited
+    visited,
+    validating
   }
 }
 

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -132,7 +132,8 @@ export type FieldConfig = {
   getValidator?: GetFieldValidator,
   initialValue?: any,
   isEqual?: IsEqual,
-  validateFields?: string[]
+  validateFields?: string[],
+  subscribeToEachFieldsPromise?: boolean
 }
 
 export type RegisterField = (
@@ -161,10 +162,12 @@ export type InternalFieldState = {
     [number]: GetFieldValidator
   },
   valid: boolean,
-  visited: boolean
+  visited: boolean,
+  subscribeToEachFieldsPromise?: boolean
 }
 
 export type InternalFormState<FormValues: FormValuesShape> = {
+  fieldsWithPromisePending?: Object,
   active?: string,
   dirtySinceLastSubmit: boolean,
   error?: any,


### PR DESCRIPTION
Sometimes when uploading files directly from input on change, instead of on submit, in that case that Field needs to provide a key like ```validating``` equals to true  till promise resolves, to show loader.

Every Field providing ```subscribeToEachFieldsPromise``` equals to true will receive notification every time validate function's promise is resolves.