### PR TITLE
Added data to FieldConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,10 @@ A callback to notify fields after submission has completed successfully.
 
 A function to call just before calling `onSubmit`. If `beforeSubmit` returns `false`, the submission will be aborted. If one of your fields returns `false` on `beforeSubmit`, other fields may not have their `beforeSubmit` called, as the submission is aborted on the first one that returns `false`.
 
+#### `data?: any`
+
+Initial state for arbitrary values to be placed by mutators.
+
 #### `defaultValue?: any`
 
 ⚠️ You probably want `initialValue`! ⚠️

--- a/src/FinalForm.creation.test.js
+++ b/src/FinalForm.creation.test.js
@@ -114,4 +114,35 @@ describe('FinalForm.creation', () => {
       pristine: false
     })
   })
+
+  it('should allow data to come from field when registered', () => {
+    const form = createForm({ onSubmit: onSubmitMock })
+    const foo = jest.fn()
+    const cat = jest.fn()
+    form.registerField(
+      'foo',
+      foo,
+      { pristine: true, data: true },
+      { data: { foo: 'bar' } }
+    )
+    expect(form.getFieldState('foo').data).toEqual({ foo: 'bar' })
+    form.registerField(
+      'cat',
+      cat,
+      { pristine: true, data: true },
+      { data: { foo: 'fubar' } }
+    )
+    expect(form.getFieldState('cat').data).toEqual({ foo: 'fubar' })
+
+    expect(foo).toHaveBeenCalledTimes(1)
+    expect(foo.mock.calls[0][0]).toMatchObject({
+      pristine: true,
+      data: { foo: 'bar' }
+    })
+    expect(cat).toHaveBeenCalledTimes(1)
+    expect(cat.mock.calls[0][0]).toMatchObject({
+      pristine: true,
+      data: { foo: 'fubar' }
+    })
+  })
 })

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -761,7 +761,7 @@ function createForm<FormValues: FormValuesShape>(
           beforeSubmit: fieldConfig && fieldConfig.beforeSubmit,
           blur: () => api.blur(name),
           change: value => api.change(name, value),
-          data: {},
+          data: (fieldConfig && fieldConfig.data) || {},
           focus: () => api.focus(name),
           isEqual: (fieldConfig && fieldConfig.isEqual) || tripleEquals,
           lastFieldState: undefined,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -128,6 +128,7 @@ type GetFieldValidator<FieldValue> = () => FieldValidator<FieldValue>
 export interface FieldConfig<FieldValue> {
   afterSubmit?: () => void
   beforeSubmit?: () => void | false
+  data?: any
   defaultValue?: any
   getValidator?: GetFieldValidator<FieldValue>
   initialValue?: any

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -130,6 +130,7 @@ export type GetFieldValidator = () => ?FieldValidator
 export type FieldConfig = {
   afterSubmit?: () => void,
   beforeSubmit?: () => void | false,
+  data?: any,
   defaultValue?: any,
   getValidator?: GetFieldValidator,
   initialValue?: any,


### PR DESCRIPTION
This change would allow `form.registerField` to initialize the `data` property for the field being registered, like `initialValue`, `defaultValue`, etc. I implemented this in response to seeing #240. Hopefully I've covered all my bases.