### PR TITLE
Added internal forceUpdate flag for fields for final-form-arrays' mutators

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,6 @@
     }
   ],
   "dependencies": {
-    "@babel/runtime": "^7.3.1",
-    "final-form": "file:.yalc/final-form",
-    "final-form-arrays": "file:.yalc/final-form-arrays"
+    "@babel/runtime": "^7.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,8 @@
     }
   ],
   "dependencies": {
-    "@babel/runtime": "^7.3.1"
+    "@babel/runtime": "^7.3.1",
+    "final-form": "file:.yalc/final-form",
+    "final-form-arrays": "file:.yalc/final-form-arrays"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -123,7 +123,9 @@ type FieldValidator<FieldValue> = (
   allValues: object,
   meta?: FieldState<FieldValue>
 ) => any | Promise<any>
-type GetFieldValidator<FieldValue> = () => FieldValidator<FieldValue> | undefined
+type GetFieldValidator<FieldValue> = () =>
+  | FieldValidator<FieldValue>
+  | undefined
 
 export interface FieldConfig<FieldValue> {
   afterSubmit?: () => void
@@ -149,6 +151,7 @@ export interface InternalFieldState<FieldValue> {
   change: (value: any) => void
   data: AnyObject
   focus: () => void
+  forceUpdate: boolean
   isEqual: IsEqual
   lastFieldState?: FieldState<FieldValue>
   length?: any

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -153,6 +153,7 @@ export type InternalFieldState = {
   change: (value: any) => void,
   data: Object,
   focus: () => void,
+  forceUpdate: boolean,
   isEqual: IsEqual,
   lastFieldState: ?FieldState,
   length?: any,


### PR DESCRIPTION
Mutators can now mark a field as `forceUpdate` to ensure that its subscribers will be notified.