### PR TITLE
Removed forceUpdate, added resetFieldState API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ es
 npm-debug.log
 .DS_Store
 yarn.lock
+yalc.lock

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ form.submit() // only submits if all validation passes
     - [`change: (value: any) => void`](#change-value-any--void-1)
     - [`data: Object`](#data-object)
     - [`focus: () => void`](#focus---void-1)
-    - [`forceUpdate: boolean`](#forceupdate-boolean)
     - [`isEqual: (a: any, b: any) => boolean`](#isequal-a-any-b-any--boolean)
     - [`modified: boolean`](#modified-boolean)
     - [`name: string`](#name-string-1)
@@ -303,6 +302,7 @@ form.submit() // only submits if all validation passes
     - [`Tools.changeValue: (state: MutableState, name: string, mutate: (value: any) => any) => void`](#toolschangevalue-state-mutablestate-name-string-mutate-value-any--any--void)
     - [`Tools.getIn: (state: Object, complexKey: string) => any`](#toolsgetin-state-object-complexkey-string--any)
     - [`Tools.renameField: (state: MutableState, from: string, to: string) => any) => void`](#toolsrenamefield-state-mutablestate-from-string-to-string--any--void)
+    - [`Tools.resetFieldState: (name: string) => void`](#toolsresetfieldstate-name-string--void)
     - [`Tools.setIn: (state: Object, key: string, value: any) => Object`](#toolssetin-state-object-key-string-value-any--object)
     - [`Tools.shallowEqual: (a: any, b: any) => boolean`](#toolsshallowequal-a-any-b-any--boolean)
   - [`Unsubscribe : () => void`](#unsubscribe----void)
@@ -842,6 +842,10 @@ Resets the values back to the initial values the form was initialized with. Or e
 
 Note that if you are calling `reset()` and not specify new initial values, you must call it with no arguments. Be careful to avoid things like `promise.catch(reset)` or `onChange={form.reset}` in React, as they will get arguments passed to them and reinitialize your form.
 
+#### `resetFieldState: (name: string) => void`
+
+Resets all of a field's flags (e.g. `touched`, `visited`, etc.) to their initial state.
+
 #### `resumeValidation: () => void`
 
 Resumes validation paused by `pauseValidation()`. If validation was blocked while it was paused, validation will be run.
@@ -1105,10 +1109,6 @@ A place for arbitrary values to be placed by mutators.
 
 A function to focus the field (mark it as active).
 
-#### `forceUpdate: boolean`
-
-When set to `true`, this field's subscribers will be sent a notification even if the state has not changed.
-
 #### `isEqual: (a: any, b: any) => boolean`
 
 A function to determine if two values are equal. Used to calculate
@@ -1273,6 +1273,10 @@ dot-and-bracket syntax (e.g. `some.deep.values[3].whatever`).
 #### `Tools.renameField: (state: MutableState, from: string, to: string) => any) => void`
 
 A utility function to rename a field, copying over its value and field subscribers. _Advanced usage only_.
+
+#### `Tools.resetFieldState: (name: string) => void`
+
+A utility function to reset all of a field's flags (e.g. `touched`, `visited`, etc.) to their initial state. This can be useful for inserting a new field that has the same name as an existing field.
 
 #### `Tools.setIn: (state: Object, key: string, value: any) => Object`
 

--- a/package.json
+++ b/package.json
@@ -92,11 +92,11 @@
     },
     {
       "path": "dist/final-form.es.js",
-      "maxSize": "8.50kB"
+      "maxSize": "8.60kB"
     },
     {
       "path": "dist/final-form.cjs.js",
-      "maxSize": "8.60kB"
+      "maxSize": "8.70kB"
     }
   ],
   "dependencies": {

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -842,9 +842,7 @@ function createForm<FormValues: FormValuesShape>(
       })
 
       return () => {
-        if (state.fields[name]) {
-          delete state.fields[name].validators[index]
-        }
+        delete state.fields[name].validators[index]
         delete state.fieldSubscribers[name].entries[index]
         if (!Object.keys(state.fieldSubscribers[name].entries).length) {
           delete state.fieldSubscribers[name]
@@ -891,6 +889,10 @@ function createForm<FormValues: FormValuesShape>(
           visited: false
         }
       }
+      runValidation(undefined, () => {
+        notifyFieldListeners()
+        notifyFormListeners()
+      })
     },
 
     resumeValidation: () => {

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -247,6 +247,7 @@ function createForm<FormValues: FormValuesShape>(
         changeValue,
         getIn,
         renameField,
+        resetFieldState: api.resetFieldState,
         setIn,
         shallowEqual
       })
@@ -458,7 +459,7 @@ function createForm<FormValues: FormValuesShape>(
       const field = safeFields[name]
       const fieldState = publishFieldState(formState, field)
       const { lastFieldState } = field
-      if (!shallowEqual(fieldState, lastFieldState) || field.forceUpdate) {
+      if (!shallowEqual(fieldState, lastFieldState)) {
         // **************************************************************
         // Curious about why a field is getting notified? Uncomment this.
         // **************************************************************
@@ -490,10 +491,9 @@ function createForm<FormValues: FormValuesShape>(
             fieldState,
             lastFieldState,
             filterFieldState,
-            field.forceUpdate
+            lastFieldState === undefined
           )
         }
-        field.forceUpdate = false
       }
     })
   }
@@ -778,7 +778,6 @@ function createForm<FormValues: FormValuesShape>(
           change: value => api.change(name, value),
           data: (fieldConfig && fieldConfig.data) || {},
           focus: () => api.focus(name),
-          forceUpdate: false,
           isEqual: (fieldConfig && fieldConfig.isEqual) || tripleEquals,
           lastFieldState: undefined,
           modified: false,
@@ -874,6 +873,24 @@ function createForm<FormValues: FormValuesShape>(
       delete state.formState.submitErrors
       delete state.formState.lastSubmittedValues
       api.initialize(initialValues || {})
+    },
+
+    /**
+     * Resets all field flags (e.g. touched, visited, etc.) to their initial state
+     */
+    resetFieldState: (name: string) => {
+      state.fields[name] = {
+        ...state.fields[name],
+        ...{
+          active: false,
+          lastFieldState: undefined,
+          modified: false,
+          touched: false,
+          valid: true,
+          validating: false,
+          visited: false
+        }
+      }
     },
 
     resumeValidation: () => {

--- a/src/FinalForm.subscribing.test.js
+++ b/src/FinalForm.subscribing.test.js
@@ -958,7 +958,6 @@ describe('FinalForm.subscribing', () => {
   })
 
   it('should allow field state to be reset', () => {
-    let unregisterBar
     const form = createForm({ onSubmit: onSubmitMock })
     const foo = jest.fn()
     form.registerField('foo', foo, { touched: true, visited: true })

--- a/src/FinalForm.subscribing.test.js
+++ b/src/FinalForm.subscribing.test.js
@@ -956,4 +956,34 @@ describe('FinalForm.subscribing', () => {
     expect(foo).toHaveBeenCalledTimes(3)
     expect(bar).toHaveBeenCalledTimes(2)
   })
+
+  it('should allow field state to be reset', () => {
+    let unregisterBar
+    const form = createForm({ onSubmit: onSubmitMock })
+    const foo = jest.fn()
+    form.registerField('foo', foo, { touched: true, visited: true })
+
+    expect(foo).toHaveBeenCalled()
+    expect(foo).toHaveBeenCalledTimes(1)
+    expect(foo.mock.calls[0][0].touched).toBe(false)
+    expect(foo.mock.calls[0][0].visited).toBe(false)
+
+    form.focus('foo')
+
+    expect(foo).toHaveBeenCalledTimes(2)
+    expect(foo.mock.calls[1][0].touched).toBe(false)
+    expect(foo.mock.calls[1][0].visited).toBe(true)
+
+    form.blur('foo')
+
+    expect(foo).toHaveBeenCalledTimes(3)
+    expect(foo.mock.calls[2][0].touched).toBe(true)
+    expect(foo.mock.calls[2][0].visited).toBe(true)
+
+    form.resetFieldState('foo')
+
+    expect(foo).toHaveBeenCalledTimes(4)
+    expect(foo.mock.calls[3][0].touched).toBe(false)
+    expect(foo.mock.calls[3][0].visited).toBe(false)
+  })
 })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -151,7 +151,6 @@ export interface InternalFieldState<FieldValue> {
   change: (value: any) => void
   data: AnyObject
   focus: () => void
-  forceUpdate: boolean
   isEqual: IsEqual
   lastFieldState?: FieldState<FieldValue>
   length?: any
@@ -202,6 +201,7 @@ export interface FormApi<FormValues = object> {
   pauseValidation: () => void
   registerField: RegisterField<any>
   reset: (initialValues?: object) => void
+  resetFieldState: (name: string) => void
   resumeValidation: () => void
   setConfig: (name: ConfigKey, value: any) => void
   submit: () => Promise<FormValues | undefined> | undefined
@@ -241,6 +241,7 @@ export interface Tools<FormValues> {
   changeValue: ChangeValue<FormValues>
   getIn: GetIn
   renameField: RenameField<FormValues>
+  resetFieldState: (name: string) => void
   setIn: SetIn
   shallowEqual: IsEqual
 }

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -153,7 +153,6 @@ export type InternalFieldState = {
   change: (value: any) => void,
   data: Object,
   focus: () => void,
-  forceUpdate: boolean,
   isEqual: IsEqual,
   lastFieldState: ?FieldState,
   length?: any,
@@ -212,6 +211,7 @@ export type FormApi<FormValues: FormValuesShape> = {
   pauseValidation: () => void,
   registerField: RegisterField,
   reset: (initialValues?: Object) => void,
+  resetFieldState: (name: string) => void,
   resumeValidation: () => void,
   setConfig: (name: ConfigKey, value: any) => void,
   submit: () => ?Promise<?Object>,
@@ -256,6 +256,7 @@ export type Tools<FormValues: FormValuesShape> = {
   changeValue: ChangeValue<FormValues>,
   getIn: GetIn,
   renameField: RenameField<FormValues>,
+  resetFieldState: string => void,
   setIn: SetIn,
   shallowEqual: IsEqual
 }


### PR DESCRIPTION
Reverts #244.

Added new `resetFieldState` API to allow field flags to be cleared. This is all part of fixing `final-form-arrays` bugs, e.g. https://github.com/final-form/final-form-arrays/issues/18.