### PR TITLE
Fixed config typing for mutators

### DIFF
--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -120,7 +120,11 @@ form2.subscribe(
 )
 
 // mutators
-const setValue: Mutator = ([name, newValue], state, { changeValue }) => {
+const setValue: Mutator<FormValues2> = (
+  [name, newValue],
+  state,
+  { changeValue }
+) => {
   changeValue(state, name, value => newValue)
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -264,7 +264,7 @@ export interface Config<FormValues = object> {
   destroyOnUnregister?: boolean
   initialValues?: FormValues
   keepDirtyOnReinitialize?: boolean
-  mutators?: { [key: string]: Mutator }
+  mutators?: { [key: string]: Mutator<FormValues> }
   onSubmit: (
     values: FormValues,
     form: FormApi<FormValues>,


### PR DESCRIPTION
Hello, Eric (and whoever checks this tiny PR)!
I've found a small inconsistency in TypeScript type definitions: custom type of mutator is not passed down to it in the `Config` interface, which leads to use of the default placeholder type (which is `object` currently, you can see it on line 256). This PR fixes this small issue and updates the appropriate unit test.

Thank you for a great job around Final Form! 👍 