### PR TITLE
No safeFields copy

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -346,7 +346,7 @@ function createForm<FormValues: FormValuesShape>(
     }
 
     const { fields, formState } = state
-    const safeFields = { ...fields }
+    const safeFields: $ReadOnly<typeof fields> = fields;
     let fieldKeys = Object.keys(safeFields)
     if (
       !validate &&
@@ -475,7 +475,7 @@ function createForm<FormValues: FormValuesShape>(
       return
     }
     const { fields, fieldSubscribers, formState } = state
-    const safeFields = { ...fields }
+    const safeFields: $ReadOnly<typeof fields> = fields;
     const notifyField = (name: string) => {
       const field = safeFields[name]
       const fieldState = publishFieldState(formState, field)
@@ -510,7 +510,7 @@ function createForm<FormValues: FormValuesShape>(
 
   const calculateNextFormState = (): FormState<FormValues> => {
     const { fields, formState, lastFormState } = state
-    const safeFields = { ...fields }
+    const safeFields: $ReadOnly<typeof fields> = fields;
     const safeFieldKeys = Object.keys(safeFields)
 
     // calculate dirty/pristine
@@ -720,7 +720,7 @@ function createForm<FormValues: FormValuesShape>(
 
     initialize: (data: Object | ((values: Object) => Object)) => {
       const { fields, formState } = state
-      const safeFields = { ...fields }
+      const safeFields: $ReadOnly<typeof fields> = fields;
       const values = typeof data === 'function' ? data(formState.values) : data
       if (!keepDirtyOnReinitialize) {
         formState.values = values


### PR DESCRIPTION
Probably less reliable, because I'm not sure how strict flow is about
the $ReadOnly annotation when variables move across function boundaries.
However, copies of "fields" for large forms are very expensive, so it's
worth it to avoid them.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
