### PR TITLE
FinalForm.js: Allow nested batch() calls

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -199,7 +199,7 @@ function createForm<FormValues: FormValuesShape>(
     },
     lastFormState: undefined
   }
-  let inBatch = false
+  let inBatch = 0
   let validationPaused = false
   let validationBlocked = false
   let nextAsyncValidationKey = 0
@@ -634,9 +634,9 @@ function createForm<FormValues: FormValuesShape>(
 
   const api: FormApi<FormValues> = {
     batch: (fn: () => void) => {
-      inBatch = true
+      inBatch++
       fn()
-      inBatch = false
+      inBatch--
       notifyFieldListeners()
       notifyFormListeners()
     },


### PR DESCRIPTION
By turning inBatch from a flag to a semaphore.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
