### PR TITLE
Use defaultValue when initialValue(s) is undefined

### DIFF
--- a/docs/types/FieldConfig.md
+++ b/docs/types/FieldConfig.md
@@ -41,9 +41,8 @@ any
 ```
 
 Optional.
-⚠️ You probably want [`initialValue`](#initialvalue)! ⚠️
 
-The value of the field upon creation. _**This value is only needed if you want your field be `dirty` upon creation (i.e. for its value to be different from its initial value).**_
+The value of the field upon creation only if both `initialValue` is `undefined` and the value from `initialValues` is also `undefined`. The field will be `dirty` when `defaultValue` is used.
 
 ## `getValidator`
 

--- a/docs/types/FieldConfig.md
+++ b/docs/types/FieldConfig.md
@@ -42,7 +42,7 @@ any
 
 Optional.
 
-The value of the field upon creation only if both `initialValue` is `undefined` and the value from `initialValues` is also `undefined`. The field will be `dirty` when `defaultValue` is used.
+The value of the field upon creation only if both the field's [`initialValue`](#initialvalue) is `undefined` and the value from the form's [`initialValues`](FormState.md#initialvalues) is also `undefined`. The field will be `dirty` when `defaultValue` is used.
 
 ## `getValidator`
 

--- a/src/FinalForm.creation.test.js
+++ b/src/FinalForm.creation.test.js
@@ -81,31 +81,46 @@ describe('FinalForm.creation', () => {
   })
 
   it('should allow default value to come from field when registered', () => {
-    const form = createForm({ onSubmit: onSubmitMock })
+    const form = createForm({ initialValues: { baz: 'baz' }, onSubmit: onSubmitMock })
+    const baz = jest.fn()
     const foo = jest.fn()
     const cat = jest.fn()
+    form.registerField(
+      'baz',
+      baz,
+      { pristine: true, initial: true, value: true },
+      { defaultValue: 'fubar' }
+    )
+    expect(form.getState().initialValues).toEqual({ baz: 'baz' })
+    expect(form.getState().values).toEqual({ baz: 'baz' })
     form.registerField(
       'foo',
       foo,
       { pristine: true, initial: true, value: true },
       { initialValue: 'bar', defaultValue: 'fubar' }
     )
-    expect(form.getState().initialValues).toEqual({ foo: 'bar' })
-    expect(form.getState().values).toEqual({ foo: 'fubar' })
+    expect(form.getState().initialValues).toEqual({ baz: 'baz', foo: 'bar' })
+    expect(form.getState().values).toEqual({ baz: 'baz', foo: 'bar' })
     form.registerField(
       'cat',
       cat,
       { pristine: true, initial: true, value: true },
       { defaultValue: 42 }
     )
-    expect(form.getState().initialValues).toEqual({ foo: 'bar' })
-    expect(form.getState().values).toEqual({ foo: 'fubar', cat: 42 })
+    expect(form.getState().initialValues).toEqual({ baz: 'baz', foo: 'bar' })
+    expect(form.getState().values).toEqual({ baz: 'baz', foo: 'bar', cat: 42 })
 
+    expect(baz).toHaveBeenCalledTimes(1)
+    expect(baz.mock.calls[0][0]).toMatchObject({
+      value: 'baz',
+      initial: 'baz',
+      pristine: true
+    })
     expect(foo).toHaveBeenCalledTimes(1)
     expect(foo.mock.calls[0][0]).toMatchObject({
-      value: 'fubar',
+      value: 'bar',
       initial: 'bar',
-      pristine: false
+      pristine: true
     })
     expect(cat).toHaveBeenCalledTimes(1)
     expect(cat.mock.calls[0][0]).toMatchObject({

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -814,7 +814,7 @@ function createForm<FormValues: FormValuesShape>(
             fieldConfig.initialValue
           )
         }
-        if (fieldConfig.defaultValue !== undefined) {
+        if (fieldConfig.defaultValue !== undefined && fieldConfig.initialValue === undefined && (state.formState.initialValues || {})[name] === undefined) {
           state.formState.values = setIn(
             state.formState.values,
             name,

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -814,7 +814,7 @@ function createForm<FormValues: FormValuesShape>(
             fieldConfig.initialValue
           )
         }
-        if (fieldConfig.defaultValue !== undefined && fieldConfig.initialValue === undefined && (state.formState.initialValues || {})[name] === undefined) {
+        if (fieldConfig.defaultValue !== undefined && fieldConfig.initialValue === undefined && getIn(state.formState.initialValues || {}, name) === undefined) {
           state.formState.values = setIn(
             state.formState.values,
             name,


### PR DESCRIPTION
PR for a potential solution for issue [#387](https://github.com/final-form/react-final-form/issues/387)

Set `defaultValue` if:
- `defaultValue` in `<Field/>` is not `undefined`
- `initialValue` in `<Field/>` is undefined
- value from `initialValues` in form `Config` is `undefined`