### PR TITLE
docs(README): remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![codecov.io](https://codecov.io/gh/final-form/final-form/branch/master/graph/badge.svg)](https://codecov.io/gh/final-form/final-form)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
-✅ **Zero** dependencies [\*](#zero-dependencies)
+✅ **Zero** dependencies
 
 ✅ Framework agnostic
 


### PR DESCRIPTION
This used to link to a note added in #180:

>  Technically there is a dependency on `@babel/runtime`, but [this actually makes your final bundle size _smaller_ by sharing common babel code between libraries](https://babeljs.io/docs/en/babel-runtime#why).

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
