### PR TITLE
Fix field initial value validation

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -845,7 +845,7 @@ function createForm<FormValues: FormValuesShape>(
         }
       }
 
-      if (haveValidator) {
+      if (haveValidator || config.validate) {
         runValidation(undefined, () => {
           notifyFormListeners()
           notifyFieldListeners()

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -831,6 +831,10 @@ function createForm<FormValues: FormValuesShape>(
             name,
             fieldConfig.initialValue
           )
+          runValidation(undefined, () => {
+            notifyFormListeners()
+            notifyFieldListeners()
+          })
         }
         if (
           fieldConfig.defaultValue !== undefined &&
@@ -845,7 +849,7 @@ function createForm<FormValues: FormValuesShape>(
         }
       }
 
-      if (haveValidator || config.validate) {
+      if (haveValidator) {
         runValidation(undefined, () => {
           notifyFormListeners()
           notifyFieldListeners()

--- a/src/FinalForm.validating.test.js
+++ b/src/FinalForm.validating.test.js
@@ -1375,4 +1375,25 @@ describe('Field.validation', () => {
     form.change('a', 'foo')
     expect(validate).toHaveBeenCalledTimes(3)
   })
+  it('should mark the form as valid when required fields are initialized with a value', () => {
+    const form = createForm({
+      onSubmit: onSubmitMock,
+      validate: values => {
+        const errors = {}
+        if (!values.foo) {
+          errors.foo = 'Required'
+        }
+        return errors
+      }
+    })
+    const foo = jest.fn()
+    form.registerField('foo', foo, { error: true }, { initialValue: 'bar' })
+    expect(foo).toHaveBeenCalledTimes(1)
+    expect(foo.mock.calls[0][0].error).toBe(undefined)
+    expect(form.getState().invalid).toBe(false)
+    form.change('foo', '')
+    expect(foo).toHaveBeenCalledTimes(2)
+    expect(foo.mock.calls[1][0].error).toBe('Required')
+    expect(form.getState().invalid).toBe(true)
+  })
 })


### PR DESCRIPTION
fixes #296

When a field was registered with `initialValue`, form validation was never run on that value and therefore form remained invalid.

This pr changes to run form validation on field register when there's an initial value.