### PR TITLE
stop resubmitting when validator throw an error and log the error instead

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -1008,7 +1008,7 @@ function createForm<FormValues: FormValuesShape>(
           asyncValidationPromisesKeys.map(
             key => asyncValidationPromises[Number(key)]
           )
-        ).then(api.submit, api.submit)
+        ).then(api.submit, console.error)
         return
       }
       const submitIsBlocked = beforeSubmit()

--- a/src/FinalForm.submission.test.js
+++ b/src/FinalForm.submission.test.js
@@ -1044,4 +1044,38 @@ describe('FinalForm.submission', () => {
       submitFailed: true
     })
   })
+
+  describe('async validation error', () => {
+    let spyConsoleError
+
+    beforeEach(() => {
+      spyConsoleError = jest.spyOn(console, 'error')
+    })
+
+    it('should log an error if async validation throw an error and do not freeze', async () => {
+      const onSubmit = jest.fn()
+      const validationError = new Error('uh oh error during validation')
+      const form = createForm({
+        onSubmit,
+        validate: async values => {
+          throw validationError
+        }
+      })
+      form.registerField('foo', () => {})
+      form.registerField('foo2', () => {})
+
+      form.change('foo', 'bar')
+      form.change('foo2', 'baz')
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      form.submit()
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(spyConsoleError).toHaveBeenCalledWith(validationError)
+    })
+
+    afterEach(() => {
+      spyConsoleError.mockRestore()
+    })
+  })
 })


### PR DESCRIPTION
Fix issue #308 by aborting the submit on async validation error.
