### PR TITLE
Reinitialize non-registered values with keepDirtyOnReinitialize

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     },
     {
       "path": "dist/final-form.es.js",
-      "maxSize": "8.7kB"
+      "maxSize": "8.8kB"
     },
     {
       "path": "dist/final-form.cjs.js",

--- a/package.json
+++ b/package.json
@@ -92,11 +92,11 @@
     },
     {
       "path": "dist/final-form.es.js",
-      "maxSize": "8.8kB"
+      "maxSize": "8.9kB"
     },
     {
       "path": "dist/final-form.cjs.js",
-      "maxSize": "8.9kB"
+      "maxSize": "9.0kB"
     }
   ],
   "dependencies": {

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -739,20 +739,29 @@ function createForm<FormValues: FormValuesShape>(
       if (!keepDirtyOnReinitialize) {
         formState.values = values
       }
-      Object.keys(safeFields).forEach(key => {
-        const field = safeFields[key]
-        field.modified = false
-        field.touched = false
-        field.visited = false
-        if (keepDirtyOnReinitialize) {
-          const pristine = field.isEqual(
-            getIn(formState.values, key),
-            getIn(formState.initialValues || {}, key)
-          )
-          if (pristine) {
-            // only update pristine values
-            formState.values = setIn(formState.values, key, getIn(values, key))
+      Object.keys(values).forEach(key => {
+        if (key in safeFields) {
+          const field = safeFields[key]
+          field.modified = false
+          field.touched = false
+          field.visited = false
+          if (keepDirtyOnReinitialize) {
+            const pristine = field.isEqual(
+              getIn(formState.values, key),
+              getIn(formState.initialValues || {}, key)
+            )
+            if (pristine) {
+              // only update pristine values
+              formState.values = setIn(
+                formState.values,
+                key,
+                getIn(values, key)
+              )
+            }
           }
+        } else if (keepDirtyOnReinitialize) {
+          // update any non-registered values, even when keepDirtyOnReinitialize is on
+          formState.values = setIn(formState.values, key, getIn(values, key))
         }
       })
       formState.initialValues = values


### PR DESCRIPTION
When keepDirtyOnReinitialize is not set, all non-registered values go to `form.values`, which is useful for computed values depending on such non-registered values. Replicate the same behavior when keepDirtyOnReinitialize is set as well.
