### PR TITLE
Avoid notify listener calls on field register when there's no subscriber

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "bundlesize": [
     {
       "path": "dist/final-form.umd.min.js",
-      "maxSize": "5.1kB"
+      "maxSize": "5.2kB"
     },
     {
       "path": "dist/final-form.es.js",

--- a/src/FinalForm.fieldSubscribing.test.js
+++ b/src/FinalForm.fieldSubscribing.test.js
@@ -888,4 +888,63 @@ describe('Field.subscribing', () => {
     expect(name1).toHaveBeenCalledTimes(1)
     expect(name2).toHaveBeenCalledTimes(1)
   })
+
+  it('should subscribe and unsubscribe to field state', () => {
+    const form = createForm({ onSubmit: onSubmitMock })
+    const foo = jest.fn()
+
+    form.registerField('foo')
+    const unsubscribe = form.subscribeToFieldState('foo', foo, {
+      touched: true,
+      value: true,
+      visited: true
+    })
+
+    expect(foo).not.toHaveBeenCalled()
+
+    form.change('foo', 'new value')
+
+    expect(foo).toHaveBeenCalledTimes(1)
+    expect(foo.mock.calls[0][0].value).toBe('new value')
+
+    form.focus('foo')
+    expect(foo).toHaveBeenCalledTimes(2)
+    expect(foo.mock.calls[1][0].touched).toBe(false)
+    expect(foo.mock.calls[1][0].visited).toBe(true)
+
+    form.blur('foo')
+    expect(foo).toHaveBeenCalledTimes(3)
+    expect(foo.mock.calls[2][0].touched).toBe(true)
+    expect(foo.mock.calls[2][0].visited).toBe(true)
+
+    unsubscribe()
+    form.change('foo', 'newer value')
+    form.focus('foo')
+    form.blur('foo')
+    expect(foo).toHaveBeenCalledTimes(3)
+  })
+
+  it('should subscribe and unsubscribe to field state with only value subscription', () => {
+    const form = createForm({ onSubmit: onSubmitMock })
+    const foo = jest.fn()
+
+    form.registerField('foo')
+    const unsubscribe = form.subscribeToFieldState('foo', foo, { value: true })
+
+    expect(foo).not.toHaveBeenCalled()
+
+    form.change('foo', 'new value')
+
+    expect(foo).toHaveBeenCalledTimes(1)
+    expect(foo.mock.calls[0][0].value).toBe('new value')
+
+    form.focus('foo')
+    expect(foo).toHaveBeenCalledTimes(1)
+    form.blur('foo')
+    expect(foo).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    form.change('foo', 'newer value')
+    expect(foo).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -118,7 +118,7 @@ export type Subscribers<T extends Object> = {
       subscriber: Subscriber<T>
       subscription: Subscription
       notified: boolean
-    }
+    } | void
   }
 }
 
@@ -217,6 +217,11 @@ export interface FormApi<FormValues = object> {
   subscribe: (
     subscriber: FormSubscriber<FormValues>,
     subscription: FormSubscription
+  ) => Unsubscribe
+  subscribeToExistingField: (
+    name: string,
+    subscriber: FieldSubscriber<any>,
+    subscription: FieldSubscription
   ) => Unsubscribe
 }
 

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -116,7 +116,7 @@ export type FieldSubscriber = Subscriber<FieldState>
 export type Subscribers<T: Object> = {
   index: number,
   entries: {
-    [number]: {
+    [number]: ?{
       subscriber: Subscriber<T>,
       subscription: Subscription,
       notified: boolean
@@ -146,8 +146,8 @@ export type FieldConfig = {
 
 export type RegisterField = (
   name: string,
-  subscriber: FieldSubscriber,
-  subscription: FieldSubscription,
+  subscriber?: FieldSubscriber,
+  subscription?: FieldSubscription,
   config?: FieldConfig
 ) => Unsubscribe
 
@@ -224,6 +224,11 @@ export type FormApi<FormValues: FormValuesShape> = {
   subscribe: (
     subscriber: FormSubscriber<FormValues>,
     subscription: FormSubscription
+  ) => Unsubscribe,
+  subscribeToFieldState: (
+    name: string,
+    subscriber: FieldSubscriber,
+    subscription: FieldSubscription
   ) => Unsubscribe
 }
 


### PR DESCRIPTION
Hello, I'm trying to address an issue with performance in react-final-form: https://github.com/final-form/react-final-form/issues/667

The only way I could do this was to separate the registration and subscription of the field, slightly modifying the current `registerField` api to optionally accept the subscriber.

The major performance issue that I've found with react-final-form was that it was using `registerField` to register for the first time to get the initial values, unregister, then register again for subscribing to the subsequent updates to the form.  And each time it registered, it fired off notify subscription on all previously registered fields.  So, if you are trying to render 100 fields on the screen, that's 2 registration per field and 10100 or `n(n + 1)` notifications per field, I think. :)

Anyway, I was trying to optimize this by not having to call notification on registration and avoid the second registration, so I've updated the api to what you see here.  I'll PR my changes for react-final-form shortly.