### PR TITLE
Remove node 8 & 9 from testes environments on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
 notifications:
   email: false
 node_js:
-  - '8'
-  - '9'
   - '10'
   - '11'
 script:


### PR DESCRIPTION
They dont build anyway because you are using `lint-staged` version that has dropped support for nodes older than 10~. Alternatively `lint-staged` could be moved out of `"prepare"` script.