### PR TITLE
Fix submit errors for «dot-and-bracket» field names

### DIFF
--- a/src/FinalForm.fieldSubscribing.test.js
+++ b/src/FinalForm.fieldSubscribing.test.js
@@ -200,6 +200,56 @@ describe('Field.subscribing', () => {
     expect(spy.mock.calls[2][0].error).toBe('Required')
   })
 
+  it('should allow subscribing to submitError', () => {
+    const fooSubmitError = 'Foo shall not pass'
+    const fooBarSubmitError = '«Foo.bar» shall not pass'
+    const bazQuxSubmitError = 'baz["qux"] shall not pass'
+
+    const {
+      foo: { spy: fooSpy },
+      'foo.bar': { spy: fooBarSpy },
+      'baz.qux': { spy: bazQuxSpy },
+      form,
+    } = prepareFieldSubscribers(
+      {},
+      {
+        foo: { submitError: true },
+        'foo.bar': { submitError: true },
+        'baz.qux': { submitError: true },
+      },
+      {},
+      {
+        onSubmit: () => ({
+          foo: fooSubmitError,
+          'foo.bar': fooBarSubmitError,
+          baz: { qux: bazQuxSubmitError },
+        })
+      }
+    )
+
+    expect(fooSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ submitError: undefined })
+    )
+    expect(fooBarSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ submitError: undefined })
+    )
+    expect(bazQuxSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ submitError: undefined })
+    )
+
+    form.submit()
+
+    expect(fooSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ submitError: fooSubmitError })
+    )
+    expect(fooBarSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ submitError: fooBarSubmitError })
+    )
+    expect(bazQuxSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ submitError: bazQuxSubmitError })
+    )
+  })
+
   it('should allow subscribing to initial', () => {
     const {
       form,

--- a/src/FinalForm.subscribing.test.js
+++ b/src/FinalForm.subscribing.test.js
@@ -488,6 +488,29 @@ describe('FinalForm.subscribing', () => {
     expect(spy.mock.calls[1][0].submitErrors).toEqual({ foo: 'Why no foo?' })
   })
 
+  it('should allow subscribing to nested submit errors', () => {
+    const simpleStringSubmitError = '«foo.bar» shall not pass!'
+    const nestedObjectSubmitError = 'foo["baz"] shall not pass!'
+
+    const form = createForm({
+      onSubmit: () => ({
+        'foo.bar': simpleStringSubmitError,
+        foo: { baz: nestedObjectSubmitError },
+      })
+    })
+
+    const spy = jest.fn()
+    form.subscribe(spy, { submitErrors: true })
+
+    form.submit()
+    expect(spy).toHaveBeenLastCalledWith({
+      submitErrors: {
+        'foo.bar': simpleStringSubmitError,
+        foo: { baz: nestedObjectSubmitError },
+      },
+    })
+  })
+
   it('should allow subscribing to hasSubmitErrors', () => {
     const onSubmit = jest.fn(values => {
       const errors = {}

--- a/src/structure/getIn.js
+++ b/src/structure/getIn.js
@@ -3,6 +3,15 @@ import toPath from './toPath'
 import type { GetIn } from '../types'
 
 const getIn: GetIn = (state: Object, complexKey: string): any => {
+  const hasDirectKey =
+    state !== null &&
+    (typeof state === 'object' || Array.isArray(state)) &&
+    state.hasOwnProperty(complexKey)
+
+  if (hasDirectKey) {
+    return state[complexKey]
+  }
+
   // Intentionally using iteration rather than recursion
   const path = toPath(complexKey)
   let current: any = state

--- a/src/structure/getIn.test.js
+++ b/src/structure/getIn.test.js
@@ -49,4 +49,16 @@ describe('structure.getIn', () => {
     expect(getIn({ a: [{ b: 2 }] }, 'a[0].b')).toBe(2)
     expect(getIn({ a: ['first', [{ b: 'c' }]] }, 'a[1][0].b')).toBe('c')
   })
+
+  it('should get "path-like" key', () => {
+    expect(getIn({ 'a.b': 'c' }, 'a.b')).toBe('c')
+    expect(getIn({ 'a.b': undefined }, 'a.b')).toBeUndefined()
+    expect(getIn({ 'a[0]': 1 }, 'a[0]')).toBe(1)
+  })
+
+  it('should prefer "path-like" key when both key types exists', () => {
+    expect(getIn({ 'a.b': 'c', a: { b: 'd' } }, 'a.b')).toBe('c')
+    expect(getIn({ 'a.b': undefined, a: { b: true } }, 'a.b')).toBeUndefined()
+    expect(getIn({ 'a[0]': true, a: [false] }, 'a[0]')).toBe(true)
+  })
 })


### PR DESCRIPTION
Allow to return submit errors using «dot-and-bracket» syntax.
**Demo of issue**: https://codesandbox.io/s/pensive-bhabha-veklh

The problem doesn't occur when `getIn` function works more like lodash `get` one:
```js
_.get({ 'a.b': true }, 'a.b') // returns 'true'
_.get({ 'a.b': true, a: { b: false } }, 'a.b') // returns 'true'
```