### PR TITLE
Optimize toPath method by caching results

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     },
     {
       "path": "dist/final-form.cjs.js",
-      "maxSize": "9.0kB"
+      "maxSize": "9.1kB"
     }
   ],
   "dependencies": {

--- a/src/structure/toPath.js
+++ b/src/structure/toPath.js
@@ -1,4 +1,7 @@
 // @flow
+const keysCache: {[string]: string[]} = {}
+const keysRegex = /[.[\]]+/;
+
 const toPath = (key: string): string[] => {
   if (key === null || key === undefined || !key.length) {
     return []
@@ -6,7 +9,10 @@ const toPath = (key: string): string[] => {
   if (typeof key !== 'string') {
     throw new Error('toPath() expects a string')
   }
-  return key.split(/[.[\]]+/).filter(Boolean)
+  if(keysCache[key] == null) {
+    keysCache[key] = key.split(keysRegex).filter(Boolean)
+  }
+  return keysCache[key];
 }
 
 export default toPath


### PR DESCRIPTION
Hi,

We have some performance issue with big form (more thousand field) and we find that `toPath` method take a long time. As it is a pure fonction, by caching results, we get a significant improvement.

What do you think about this optimisation ?

Thanks in advance.