### PR TITLE
[TYPESCRIPT] Change Config.initialValue type to Partial

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     }
   ],
   "dependencies": {
-    "@babel/runtime": "^7.8.3"
+    "@babel/runtime": "^7.8.3",
+    "@typescript-eslint/parser": "^2.22.0"
   }
 }

--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -99,6 +99,7 @@ interface FormValues2 {
   a: string
   b: boolean
   c: number
+  d?: string
 }
 const initialValues: Config<FormValues2>['initialValues'] = {
   a: 'a',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -264,7 +264,7 @@ export type Mutator<FormValues = object> = (
 export interface Config<FormValues = object> {
   debug?: DebugFunction<FormValues>
   destroyOnUnregister?: boolean
-  initialValues?: FormValues
+  initialValues?: Partial<FormValues>
   keepDirtyOnReinitialize?: boolean
   mutators?: { [key: string]: Mutator<FormValues> }
   onSubmit: (

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -276,7 +276,7 @@ export type Mutator<FormValues: FormValuesShape> = (
 export type Config<FormValues: FormValuesShape> = {
   debug?: DebugFunction<FormValues>,
   destroyOnUnregister?: boolean,
-  initialValues?: Partial<FormValues>,
+  initialValues?: $Shape<FormValues>,
   keepDirtyOnReinitialize?: boolean,
   mutators?: { [string]: Mutator<FormValues> },
   onSubmit: (

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -276,7 +276,7 @@ export type Mutator<FormValues: FormValuesShape> = (
 export type Config<FormValues: FormValuesShape> = {
   debug?: DebugFunction<FormValues>,
   destroyOnUnregister?: boolean,
-  initialValues?: FormValues,
+  initialValues?: Partial<FormValues>,
   keepDirtyOnReinitialize?: boolean,
   mutators?: { [string]: Mutator<FormValues> },
   onSubmit: (


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
## What's new?
- Dependency: @typescript-eslint/parser
> **Why?** Because when I tried to run `yarn precommit`, I got an error `cannot find module name @typescript-esline/parser`

- Suggestion to change Type of InitialValue on Config Type from FormValue to Partial<FormValue>
- Suggestion to change FlowType of InitialValue Config Type from FormValue to $Shape<FormValue>

---

## Background
- I'm developing a component using `react-final-form`, and found that I need to declare all of my type for my initialValue, while actually I only need to add 1 attribute instead of all the the attribute.

![image](https://user-images.githubusercontent.com/29723619/76160891-8d15eb00-6160-11ea-8aec-c52dcfd56f6b.png)
