### PR TITLE
docs: remove CodeFund sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<p align="center">
-<a href="https://codefund.io/properties/556/visit-sponsor">
-<img src="https://codefund.io/properties/556/sponsor" />
-</a>
-</p>
-
 [<img src="form-nerd-logo.png" align="left"/>](https://formnerd.co/final-form-readme) **You build great forms, but do you know HOW users use your forms? [Find out with Form Nerd!](https://formnerd.co/final-form-readme) Professional analytics from the creator of Final Form.**
 
 ---


### PR DESCRIPTION
**What**:

Remove CodeFund sponsor ad from the README

**Why**:

CodeFund is not allowed to place ads on README's anymore according to GitHub.
Please reach out to our team if you have any questions :slightly_smiling_face: 