### PR TITLE
Fix missing FieldState argument if validator function is wrapped

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -316,7 +316,7 @@ function createForm<FormValues: FormValuesShape>(
         const errorOrPromise = validator(
           getIn(state.formState.values, field.name),
           state.formState.values,
-          validator.length === 3
+          validator.length === 0 || validator.length === 3
             ? publishFieldState(state.formState, state.fields[field.name])
             : undefined
         )

--- a/src/FinalForm.validating.test.js
+++ b/src/FinalForm.validating.test.js
@@ -1396,4 +1396,36 @@ describe('Field.validation', () => {
     expect(foo.mock.calls[1][0].error).toBe('Required')
     expect(form.getState().invalid).toBe(true)
   })
+
+  it('should pass in all three arguments into a wrapped validate function with unknown number of arguments', () => {
+    const form = createForm({
+      onSubmit: onSubmitMock
+    });
+    const noArg = jest.fn()
+    
+    form.registerField('foo', () => {}, { error: true }, { initialValue: 'value', getValidator: () => noArg })
+    const meta = form.getFieldState('foo')
+    const { values } = form.getState()
+
+    expect(noArg).toHaveBeenNthCalledWith(1, values.foo, values, meta)
+  })
+
+  it('should not pass field state to a validator function with 1 or 2 arguments', () => {
+    const form = createForm({
+      onSubmit: onSubmitMock
+    });
+    const oneArg = jest.fn(val => {})
+    const twoArg = jest.fn((val, all) => {})
+    const threeArg = jest.fn((val, all, meta) => {})
+    
+    form.registerField('foo', () => {}, { error: true }, { initialValue: 'value', getValidator: () => oneArg })
+    form.registerField('bar', () => {}, { error: true }, { initialValue: 'value', getValidator: () => twoArg })
+    form.registerField('baz', () => {}, { error: true }, { initialValue: 'value', getValidator: () => threeArg })
+
+    const meta = form.getFieldState('baz')
+
+    expect(oneArg.mock.calls[0][2]).toBeUndefined()
+    expect(twoArg.mock.calls[0][2]).toBeUndefined()
+    expect(threeArg.mock.calls[0][2]).toEqual(meta)
+  })
 })


### PR DESCRIPTION
This pull request fixes a problem I noticed while working with an async field level validator, which is wrapped in a debounce function. The third argument was missing:
```
const validate = pDebounce(async (value, allValues, meta) => {
    console.log(meta); // undefined
}, 500);
```

After investigating the problem I found that `pDebounce` calls my function with a spread operator to pass on arguments: `func(...arguments)`. The function it returns has 0 (unknown) number of arguments and so `validate.length` would give us 0. This is a typical behaviour of a high order function.

In my fix I suggest to pass all three arguments to a 0 argument validator function. `validator.length === 0` would indicate unknown number args of a given function and so won't skip `fieldState`.