### PR TITLE
Add scarf-js for anonymized installation analytics

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,8 @@ or
 yarn add final-form
 ```
 
+Final Form uses [scarf-js](https://www.npmjs.com/package/@scarf/scarf) to collect anonymized installation analytics. These analytics help support the maintainers of this library. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's `package.json`. Alternatively, you can set the environment variable `SCARF_ANALYTICS=false` before you install.
+
 ## Usage
 
 The general idea is that you create a "form instance" with `createForm()`, which you can then `subscribe()` to as many times as you like, and then you can `registerField()` as many fields as your need, including registering more than once to the same field. You can then call `submit()` to call your `onSubmit` function with the values of the form.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1783,6 +1783,11 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@scarf/scarf": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.5.tgz",
+      "integrity": "sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ=="
+    },
     "@sinonjs/commons": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     }
   ],
   "dependencies": {
-    "@babel/runtime": "^7.8.3"
+    "@babel/runtime": "^7.8.3",
+    "@scarf/scarf": "^1.0.5"
   }
 }


### PR DESCRIPTION
This change adds a dependency on scarf-js for installation analytics to support the maintainers of Final Form.

Discussion from everyone is welcome! Some background on the library and the problem it's solving can be found in this post here: https://github.com/scarf-sh/scarf-js/blob/master/WHY.org. The package README (https://github.com/scarf-sh/scarf-js) has more info on exactly what data is sent on each install and how users can opt-out if they choose.

The data Scarf collects will help maintainers by keeping them informed about how the package is being used and will help drive sponsorship to support all the work that goes into Final Form. 

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
