### PR TITLE
Add types for submission and validation handlers

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -270,24 +270,24 @@ export type Mutator<FormValues = object, InitialFormValues = Partial<FormValues>
   tools: Tools<FormValues, InitialFormValues>
 ) => any
 
+export type SubmissionHandler<FormValues, InitialFormValues = Partial<FormValues>> = (
+  values: FormValues,
+  form: FormApi<FormValues, InitialFormValues>,
+  callback?: (errors?: SubmissionErrors) => void
+) => SubmissionErrors | Promise<SubmissionErrors | undefined> | undefined | void
+
+export type ValidationHandler<FormValues> = (
+  values: FormValues
+) => ValidationErrors | Promise<ValidationErrors> | undefined
+
 export interface Config<FormValues = object, InitialFormValues = Partial<FormValues>> {
   debug?: DebugFunction<FormValues, InitialFormValues>
   destroyOnUnregister?: boolean
   initialValues?: InitialFormValues
   keepDirtyOnReinitialize?: boolean
   mutators?: { [key: string]: Mutator<FormValues, InitialFormValues> }
-  onSubmit: (
-    values: FormValues,
-    form: FormApi<FormValues, InitialFormValues>,
-    callback?: (errors?: SubmissionErrors) => void
-  ) =>
-    | SubmissionErrors
-    | Promise<SubmissionErrors | undefined>
-    | undefined
-    | void
-  validate?: (
-    values: FormValues
-  ) => ValidationErrors | Promise<ValidationErrors> | undefined
+  onSubmit: SubmissionHandler<FormValues, InitialFormValues>
+  validate?: ValidationHandler<FormValues>
   validateOnBlur?: boolean
 }
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->
Proposing to export declarations for `onSubmit` and `validate` to simplify typing when declaring them outside of the config object. 