### PR TITLE
Fix form.reset type

### DIFF
--- a/docs/types/FormApi.md
+++ b/docs/types/FormApi.md
@@ -140,7 +140,7 @@ Related:
 ## `reset`
 
 ```ts
-(initialValues: ?FormValues) => void
+(initialValues: ?FormInitialValues) => void
 ```
 
 Resets the values back to the initial values the form was initialized with. Or empties all the values if the form was not initialized. If you provide `initialValues` they will be used as the new initial values.

--- a/docs/types/FormApi.md
+++ b/docs/types/FormApi.md
@@ -140,7 +140,7 @@ Related:
 ## `reset`
 
 ```ts
-(initialValues: ?FormInitialValues) => void
+(initialValues: ?InitialFormValues) => void
 ```
 
 Resets the values back to the initial values the form was initialized with. Or empties all the values if the form was not initialized. If you provide `initialValues` they will be used as the new initial values.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -215,7 +215,7 @@ export interface FormApi<FormValues = Record<string, any>, InitialFormValues = P
   mutators: Record<string, (...args: any[]) => any>
   pauseValidation: () => void
   registerField: RegisterField<FormValues>
-  reset: (initialValues?: FormValues) => void
+  reset: (initialValues?: InitialFormValues) => void
   resetFieldState: (name: keyof FormValues) => void
   resumeValidation: () => void
   setConfig: <K extends ConfigKey>(


### PR DESCRIPTION
Hey,

I think the argument for form.reset should be `InitialFormValues` instead of `FormValues`.

Cheers