### PR TITLE
Do not use defaultValue in register call if formState already has a value

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -853,9 +853,10 @@ function createForm<FormValues: FormValuesShape>(
         if (fieldConfig.getValidator) {
           state.fields[name].validators[index] = fieldConfig.getValidator
         }
+
+        const noValueInFormState = getIn(state.formState.values, name) === undefined
         if (
-          fieldConfig.initialValue !== undefined &&
-          getIn(state.formState.values, name) === undefined
+          fieldConfig.initialValue !== undefined && noValueInFormState
           // only initialize if we don't yet have any value for this field
         ) {
           state.formState.initialValues = setIn(
@@ -870,10 +871,13 @@ function createForm<FormValues: FormValuesShape>(
           )
           runValidation(undefined, notify)
         }
+
+        // only use defaultValue if we don't yet have any value for this field
         if (
           fieldConfig.defaultValue !== undefined &&
           fieldConfig.initialValue === undefined &&
-          getIn(state.formState.initialValues, name) === undefined
+          getIn(state.formState.initialValues, name) === undefined &&
+          noValueInFormState
         ) {
           state.formState.values = setIn(
             state.formState.values,


### PR DESCRIPTION
Issue:
1. Form state has value for a field
2. Calling `register` for that field name with `defaultValue` ignores the fact that form state already has a value and changes it to the default value

It seems that the same check as for `initialValue` should be used for `defaultValue` usage in `register` call.
Let me know if I'm missing something in the logic of the `register` call. 