### PR TITLE
fix(toPath): handle idiomatic JS paths with arbitrary string properties

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,57 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+====
+
+toPath implementation adapted from lodash/.internal/stringToPath.  Lodash license:
+
+The MIT License
+
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/src/structure/toPath.js
+++ b/src/structure/toPath.js
@@ -1,6 +1,50 @@
 // @flow
-const keysCache: {[string]: string[]} = {}
-const keysRegex = /[.[\]]+/
+
+const charCodeOfDot = '.'.charCodeAt(0)
+const reEscapeChar = /\\(\\)?/g
+const rePropName = RegExp(
+  // Match anything that isn't a dot or bracket.
+  '[^.[\\]]+' +
+    '|' +
+    // Or match property names within brackets.
+    '\\[(?:' +
+    // Match a non-string expression.
+    '([^"\'][^[]*)' +
+    '|' +
+    // Or match strings (supports escaping characters).
+    '(["\'])((?:(?!\\2)[^\\\\]|\\\\.)*?)\\2' +
+    ')\\]' +
+    '|' +
+    // Or match "" as the space between consecutive dots or empty brackets.
+    '(?=(?:\\.|\\[\\])(?:\\.|\\[\\]|$))',
+  'g'
+)
+
+/**
+ * Converts `string` to a property path array.
+ *
+ * @private
+ * @param {string} string The string to convert.
+ * @returns {Array} Returns the property path array.
+ */
+const stringToPath = (string) => {
+  const result = []
+  if (string.charCodeAt(0) === charCodeOfDot) {
+    result.push('')
+  }
+  string.replace(rePropName, (match, expression, quote, subString) => {
+    let key = match
+    if (quote) {
+      key = subString.replace(reEscapeChar, '$1')
+    } else if (expression) {
+      key = expression.trim()
+    }
+    result.push(key)
+  })
+  return result
+}
+
+const keysCache: { [string]: string[] } = {}
 
 const toPath = (key: string): string[] => {
   if (key === null || key === undefined || !key.length) {
@@ -10,7 +54,7 @@ const toPath = (key: string): string[] => {
     throw new Error('toPath() expects a string')
   }
   if (keysCache[key] == null) {
-    keysCache[key] = key.split(keysRegex).filter(Boolean)
+    keysCache[key] = stringToPath(key)
   }
   return keysCache[key]
 }

--- a/src/structure/toPath.test.js
+++ b/src/structure/toPath.test.js
@@ -38,4 +38,7 @@ describe('structure.toPath', () => {
       'cow'
     ])
   })
+  it('should support string properties that are not valid JS identifiers', () => {
+    expect(toPath('foo["bar.baz\\"["]')).toEqual(['foo', 'bar.baz"['])
+  })
 })


### PR DESCRIPTION
fix #380

Since doing this right is non-trivial, I copied over the code from lodash' `stringToPath` and appended lodash' license to the `LICENSE`.

Although we could use the `lodash.topath`, [those modular build packages are discouraged and will be removed in v5](https://github.com/lodash/lodash/issues/3838#issuecomment-398592530).

The better alternative, really, is just to depend on `lodash` and import `toPath` from it.  People are averse to transitive deps but only the code `toPath` depends on would get bundled, and that code could be shared with any other packages/userland code that rely on `toPath`, so it can result in smaller overall bundle sizes than duplicating the code or using the `lodash.topath` modular build package.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/master/.github/CONTRIBUTING.md

-->