### PR TITLE
DOCS: Fix restart method definition

### DIFF
--- a/docs/types/FormApi.md
+++ b/docs/types/FormApi.md
@@ -160,7 +160,7 @@ Resets all of a field's flags (e.g. `touched`, `visited`, etc.) to their initial
 ## `restart`
 
 ```ts
-() => void
+(initialValues: ?InitialFormValues) => void
 ```
 
 Resets all form and field state. Same as calling `reset()` on the form and `resetFieldState()` for each field. Form should be just as it was when it was first created.


### PR DESCRIPTION
Fix `form.restart` method definition on the docs