### PR TITLE
Fix modifiedAfterSubmit property not being reset when there are errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
   "bundlesize": [
     {
       "path": "dist/final-form.umd.min.js",
-      "maxSize": "5.3kB"
+      "maxSize": "5.4kB"
     },
     {
       "path": "dist/final-form.es.js",
-      "maxSize": "9.3kB"
+      "maxSize": "9.4kB"
     },
     {
       "path": "dist/final-form.cjs.js",

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -1078,6 +1078,7 @@ function createForm<FormValues: FormValuesShape>(
 
       if (hasSyncErrors()) {
         markAllFieldsTouched()
+        resetModifiedAfterSubmit();
         state.formState.submitFailed = true
         notifyFormListeners()
         notifyFieldListeners()

--- a/src/FinalForm.submission.test.js
+++ b/src/FinalForm.submission.test.js
@@ -222,6 +222,53 @@ describe('FinalForm.submission', () => {
     })
   })
 
+
+  it('should reset the modifiedSinceLastSubmit flag after submitting with errors', () => {
+    const onSubmit = jest.fn()
+    const validate = (values, form, callback) => {
+      const errors = {}
+      if (values.foo === 'bar') {
+        errors.foo = 'Sorry, "bar" is an illegal value'
+      }
+      return errors;
+    }
+    const form = createForm({ onSubmit, validate })
+    const spy = jest.fn()
+    expect(spy).not.toHaveBeenCalled()
+    spy.iAmTheSpySubscriber = true;
+    form.subscribe(spy, {
+      modifiedSinceLastSubmit: true,
+    })
+    form.registerField('foo', () => {})
+
+    expect(spy).toHaveBeenCalled()
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith({
+      modifiedSinceLastSubmit: false
+    })
+
+    form.change('foo', 'baz')
+
+    form.submit()
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0][0]).toEqual({ foo: 'baz' })
+
+    form.change('foo', 'bar')
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy).toHaveBeenCalledWith({
+      modifiedSinceLastSubmit: true 
+    })
+
+    form.submit()
+
+    expect(spy).toHaveBeenCalledTimes(3)
+    expect(spy).toHaveBeenCalledWith({
+      modifiedSinceLastSubmit: false 
+    })
+  })
+
   it('should support asynchronous submission with errors via callback', async () => {
     const onSubmit = jest.fn((values, form, callback) => {
       setTimeout(() => {


### PR DESCRIPTION
We noticed that the modifiedAfterSubmit property doesn't seem to get reset when there are errors. This is a slight behaviour change, but we believe this would be the correct behaviour. I've added a test case to prove the bug as well.

### Fixed

- modifiedAfterSubmit property not being reset when there are errors