### PR TITLE
Fix field-level initialValue should not be blocked by noValueInFormState

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -859,8 +859,8 @@ function createForm<FormValues: FormValuesShape>(
 
         const noValueInFormState = getIn(state.formState.values, name) === undefined
         if (
-          fieldConfig.initialValue !== undefined && noValueInFormState &&
-          (getIn(state.formState.values, name) === undefined ||
+          fieldConfig.initialValue !== undefined &&
+          (noValueInFormState ||
             getIn(state.formState.values, name) ===
               getIn(state.formState.initialValues, name))
           // only initialize if we don't yet have any value for this field


### PR DESCRIPTION
It's related to final-form/react-final-form#823.

I see #364 tried to solve this issue above, but unfortunately it conflicts with #372. 
With both pull request merged, FinalForm (as of `4.20.2`) still require a field to have “noValueInFormState” before it can apply its field-level `initialValue`.

https://github.com/final-form/final-form/blob/0d7aecbc37c140610361506781fe839b85302836/src/FinalForm.js#L860-L866

This PR tries to restore the original purpose of #364 by removing `&& noValueInFormState` requirement from the expression.