### PR TITLE
Prevent formState.values from initializing to undefined

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -809,7 +809,7 @@ function createForm<FormValues: FormValuesShape>(
       formState.values = values;
       // restore the dirty values
       Object.keys(savedDirtyValues).forEach((key) => {
-        formState.values = setIn(formState.values, key, savedDirtyValues[key]);
+        formState.values = setIn(formState.values, key, savedDirtyValues[key]) || {};
       });
       runValidation(undefined, () => {
         notifyFieldListeners();


### PR DESCRIPTION
Resolve https://github.com/final-form/final-form/issues/449

The root of the problem is `setIn` returns undefined if you pass in an undefined `value`. I assume this is intentional so I just added the `|| {}` to ensure that `form.values` can never be undefined.