### PR TITLE
fix #411: unsuscribe field before the validation finish throw unhandled rejections exception in node 16

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -8,7 +8,7 @@ const crossEnv = npsUtils.crossEnv;
 module.exports = {
   scripts: {
     test: {
-      default: crossEnv("NODE_ENV=test jest --coverage"),
+      default: crossEnv("NODE_ENV=test NODE_OPTIONS=--unhandled-rejections=strict jest --coverage"),
       update: crossEnv("NODE_ENV=test jest --coverage --updateSnapshot"),
       watch: crossEnv("NODE_ENV=test jest --watch"),
       codeCov: crossEnv(

--- a/src/FinalForm.fieldSubscribing.test.js
+++ b/src/FinalForm.fieldSubscribing.test.js
@@ -44,6 +44,20 @@ describe("Field.subscribing", () => {
     expect(form.getRegisteredFields()).toEqual(["foo", "bar", "baz"]);
   });
 
+  it("should allow register and unregister", () => {
+    const form = createForm({ onSubmit: onSubmitMock });
+    const config = { 
+      getValidator: () => () => Promise.resolve("err"),
+      silent: true, 
+    };
+    // register
+    const unsuscribe = form.registerField("foo", () => {}, {}, config);
+    // unsuscribe
+    unsuscribe();
+
+    expect(form.getRegisteredFields()).toEqual([]);
+  });
+
   it("should provide a access to field state", () => {
     const form = createForm({ onSubmit: onSubmitMock });
     form.registerField("foo", () => {}, {});

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -868,7 +868,7 @@ function createForm<FormValues: FormValuesShape>(
       let haveValidator = false;
       const silent = fieldConfig && fieldConfig.silent;
       const notify = () => {
-        if (silent) {
+        if (silent && state.fields[name]) {
           notifyFieldListeners(name);
         } else {
           notifyFormListeners();


### PR DESCRIPTION
Fix the issue #411.
Affects also the issue commented in react final form: https://github.com/final-form/react-final-form/pull/932

The problem occurs when you register a field with silent to true and with an async validator and immediately unregister it.
This is exactly what is done in React Final Form in the Field component.

The field validator, being asynchronous, terminates when the field no longer exists in the form and calls the `notifyFieldListeners` for that field.

I have changed the code so that once the validation finishes if it is `silent=true` it checks if the field still exists.

Also, in order to reproduce the bug in node before V16, I had to add the option `NODE_OPTIONS=--unhandled-rejections=strict` in the package-scripts.js

Cheers!