### PR TITLE
Add `data` property to `FormState`

### DIFF
--- a/docs/types/FormState.md
+++ b/docs/types/FormState.md
@@ -12,6 +12,14 @@ string
 
 The name of the currently active field. `undefined` if none are active.
 
+## `data`
+
+```ts
+Object
+```
+
+A place for arbitrary values to be placed by mutators.
+
 ## `dirty`
 
 ```ts

--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -77,6 +77,7 @@ const hasAnyError = (errors: Object): boolean => {
 function convertToExternalFormState<FormValues: FormValuesShape>({
   // kind of silly, but it ensures type safety ¯\_(ツ)_/¯
   active,
+  data,
   dirtySinceLastSubmit,
   modifiedSinceLastSubmit,
   error,
@@ -94,6 +95,7 @@ function convertToExternalFormState<FormValues: FormValuesShape>({
 }: InternalFormState<FormValues>): FormState<FormValues> {
   return {
     active,
+    data,
     dirty: !pristine,
     dirtySinceLastSubmit,
     modifiedSinceLastSubmit,
@@ -169,6 +171,7 @@ function createForm<FormValues: FormValuesShape>(
     throw new Error("No config specified");
   }
   let {
+    data,
     debug,
     destroyOnUnregister,
     keepDirtyOnReinitialize,
@@ -188,6 +191,7 @@ function createForm<FormValues: FormValuesShape>(
     fields: {},
     formState: {
       asyncErrors: {},
+      data: data || {},
       dirtySinceLastSubmit: false,
       modifiedSinceLastSubmit: false,
       errors: {},

--- a/src/formSubscriptionItems.js
+++ b/src/formSubscriptionItems.js
@@ -1,6 +1,7 @@
 // @flow
 export default [
   "active",
+  "data",
   "dirty",
   "dirtyFields",
   "dirtyFieldsSinceLastSubmit",

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -9,6 +9,7 @@ export type FormValuesShape = {
 
 export type FormSubscription = {
   active?: boolean,
+  data?: boolean,
   dirty?: boolean,
   dirtyFields?: boolean,
   dirtyFieldsSinceLastSubmit?: boolean,
@@ -37,6 +38,7 @@ export type FormSubscription = {
 export type FormState<FormValues: FormValuesShape> = {
   // all values are optional because they must be subscribed to
   active?: string,
+  data?: Object,
   dirty?: boolean,
   dirtyFields?: { [string]: boolean },
   dirtyFieldsSinceLastSubmit?: { [string]: boolean },
@@ -182,6 +184,7 @@ export type InternalFieldState = {
 
 export type InternalFormState<FormValues: FormValuesShape> = {
   active?: string,
+  data: Object,
   asyncErrors: Object,
   dirtySinceLastSubmit: boolean,
   modifiedSinceLastSubmit: boolean,


### PR DESCRIPTION
This commit adds a `data` property to the `FormState` object. The property serves the same purpose as the `data` property in the
`FieldState` object: It is a place for arbitrary values to be placed by mutators.