### PR TITLE
Fix for issue #456 - Fixes unwanted breaking change for array input names

### DIFF
--- a/src/structure/toPath.test.js
+++ b/src/structure/toPath.test.js
@@ -38,7 +38,13 @@ describe("structure.toPath", () => {
       "cow",
     ]);
   });
+
   it("should support string properties that are not valid JS identifiers", () => {
     expect(toPath('foo["bar.baz\\"["]')).toEqual(["foo", 'bar.baz"[']);
+  });
+
+  it("should be retrocompatible with v4.20.2 where key names like 'choices[]' and 'options[]' map to ['choices'] and ['options'] instead of ['choices', ''] and ['options', ''] as introduced by v4.20.3 (unwanted breaking change)", () => {
+    expect(toPath("choices[]")).toEqual(["choices"]);
+    expect(toPath("options[]")).toEqual(["options"]);
   });
 });


### PR DESCRIPTION
**Fix for issue #456 - Fixes unwanted breaking change for array input names introduced in v4.20.3 (a3575ef0c51277ab253e58fbb580de11de73f101) - v4.20.2 used to work fine**

Hello @erikras and @jedwards1211,

Commit a3575ef0c51277ab253e58fbb580de11de73f101 ([PR 381](https://github.com/final-form/final-form/pull/381)) introduced a breaking change for array input names like `choices[]` and `options[]` (see issue #456).

In v4.20.2, keys like `"choices[]"` and `"options[]"` all map to the following correct paths: `["choices"]`, `["options"]`.

Since v4.20.3, after [PR 381](https://github.com/final-form/final-form/pull/381) was merged, `"choices[]"` and `"options[]"`
started to map to `["choices", ""]` and `["options", ""]`, which is not retro-compatible with what we had in v4.20.2 and breaks some of our forms relying on array input names like `choices[]`.

A few months ago I created an issue about this unwanted breaking change here: https://github.com/final-form/final-form/issues/456

This PR fixes issue https://github.com/final-form/final-form/issues/456 and restores the previous behaviour for keys like `choices[]`, `options[]`, etc...

@erikras Could you please review it and release a new patch version with this patch?
We currently cannot upgrade `final-form` to v4.20.3 and above because of this issue.

Thanks!
 