### PR TITLE
Doc tweaks: Arrange `FormState`'s properties in cagtegories

### DIFF
--- a/docs/types/FormState.md
+++ b/docs/types/FormState.md
@@ -30,6 +30,44 @@ An object full of booleans, with a boolean value for each field name denoting wh
 
 An object full of booleans, with a boolean value for each field name denoting whether that field is `touched` or not. Note that this is a flat object, so if your field name is `addresses.shipping.street`, the `touched` value for that field will be available under `touched['addresses.shipping.street']`.
 
+## About modifiedness
+
+### `modified`
+
+```ts
+{ [string]: boolean }
+```
+
+An object full of booleans, with a boolean value for each field name denoting whether that field is `modified` or not. Note that this is a flat object, so if your field name is `addresses.shipping.street`, the `modified` value for that field will be available under `modified['addresses.shipping.street']`.
+
+### `modifiedSinceLastSubmit`
+
+```ts
+boolean
+```
+
+true if the form values have ever been changed since the last submission. false otherwise.
+
+
+## About values
+
+### `values`
+
+```ts
+FormValues
+```
+
+The current values of the form.
+
+### `initialValues`
+
+```ts
+FormValues
+```
+
+The values the form was initialized with. `undefined` if the form was never
+initialized.
+
 ## About dirtyness
 
 ### `pristine`


### PR DESCRIPTION
Hello.
I really appreciate this lib's reasonable and simple design.
Let me contribute on improving docs for our better understanding and wider spreading.

# Background

I have difficulty on understanding the outline of the FormState type document.  
Especially, it is very hard to visualize in mind the relation between each properties

for example, 
- `pristine === !dirty`
- `hasXErrors` for existence of any error (to prevent submit)
  - `xError` only for whole form error
  - `xErrors` for errors in fields

Honestly, I think doc's comprehensibility is a big problem and barrier for me to introduce this lib for my co-worker or Japanese brothers/sisters.

To confess, until this work, I didn't understand the whole picture of relations.

# What I did in this PR

- I arranged the properties into some groups
- I added some pseudo code to visualize the relations

# Preview in Github

[Preview in Github](https://github.com/honey32/final-form/blob/formstate-cagtegorize-properties/docs/types/FormState.md)
