### PR TITLE
Remove `object` type in `FieldValidator`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -134,14 +134,15 @@ export type Subscribers<T extends Object> = {
 
 export type Unsubscribe = () => void;
 
-export type FieldValidator<FieldValue> = (
+export type FieldValidator<FieldValue, FormValues = Record<string, unknown>> = (
   value: FieldValue,
-  allValues?: object,
-  meta?: FieldState<FieldValue>
-) => any | Promise<any>
-export type GetFieldValidator<FieldValue> = () =>
-  | FieldValidator<FieldValue>
-  | undefined;
+  allValues?: FormValues,
+  meta?: FieldState<FieldValue>,
+) => any | Promise<any>;
+export type GetFieldValidator<
+  FieldValue,
+  FormValues = Record<string, unknown>,
+> = () => FieldValidator<FieldValue, FormValues> | undefined;
 
 export interface FieldConfig<FieldValue> {
   afterSubmit?: () => void;


### PR DESCRIPTION
This PR adds an optional generic type which is used to type `allValues` in the `FieldValidator` type declaration.

Related issue #415  

## Reasoning

When trying to implement validators for your own codebase using the provided `FieldValidator` type you get a TS error when trying to type `allValues` with your form types, for example:


```ts
type FormValues= {
    a: string
    b: string
}

// Current type accepts one generic for `value`
const myValidator: FieldValidator<string> = (value, allValues?: FormValues) => !!value && !!allValues?.b
```

With TS strict mode on the above gives us the following error:

```shell
TS2322: Type '(value: string, allValues?: MyValues | undefined) => boolean' is not assignable to type 'FieldValidator<string>'.
   Types of parameters 'allValues' and 'allValues' are incompatible.
      Type 'object | undefined' is not assignable to type 'MyValues | undefined'.
         Type '{}' is missing the following properties from type 'MyValues': a, b
```

By allowing us to specify a type via an optional generic argument here we can avoid this and use our form types, something which I feel makes sense since I'm assuming `allValues` will likely just be all of the current form values at the time of validation.

We could continue to use `object` as the defaulted value if that is useful? However `Record<string, unknown>` is fairly flexible. 
