### PR TITLE
Revert validator `allValues` optional argument

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -136,7 +136,7 @@ export type Unsubscribe = () => void;
 
 export type FieldValidator<FieldValue> = (
   value: FieldValue,
-  allValues?: object,
+  allValues: object,
   meta?: FieldState<FieldValue>
 ) => any | Promise<any>
 export type GetFieldValidator<FieldValue> = () =>


### PR DESCRIPTION
I don't understand the reason why 2nd argument became optional in typings (#394), it is always being passed. Upgrading from `4.20.6` to `4.20.7` breaks the TS code.

What about to revert this change?