### PR TITLE
Update initialValues optionality in FormState TypeScript

### DIFF
--- a/src/index.d.test.ts
+++ b/src/index.d.test.ts
@@ -90,7 +90,7 @@ console.log(
   formState.error as boolean,
 );
 console.log(formState.errors as AnyObject, formState.errors!.foo);
-console.log(formState.initialValues as AnyObject, formState.initialValues.foo);
+console.log(formState.initialValues as AnyObject, formState.initialValues!.foo);
 console.log(formState.invalid as boolean);
 console.log(formState.pristine as boolean);
 console.log(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,7 @@ export interface FormState<
   errors: ValidationErrors;
   hasSubmitErrors: boolean;
   hasValidationErrors: boolean;
-  initialValues: InitialFormValues;
+  initialValues?: InitialFormValues;
   invalid: boolean;
   modified?: { [key: string]: boolean };
   modifiedSinceLastSubmit: boolean;


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/main/.github/CONTRIBUTING.md

-->
The TypeScript types for `initialValues` in form state don't reflect the code. In the createForm method, the code initializes `formState` with a [short-circuit assignment](https://github.com/final-form/final-form/blob/db16fb862c793c75955c28fd25f9e0be49e061eb/src/FinalForm.js#L194). As a result, if a consumer calls `createForm` without any initial values, `initialValues` in form state will be undefined. Marking the field as optional in the types brings it inline with the code expectation.