### PR TITLE
Fix submit func return type in typescript declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -235,7 +235,7 @@ export interface FormApi<
     name: K,
     value: Config<FormValues>[K],
   ) => void;
-  submit: () => Promise<FormValues | undefined> | undefined;
+  submit: () => Promise<SubmissionErrors | undefined> | undefined;
   subscribe: (
     subscriber: FormSubscriber<FormValues>,
     subscription: FormSubscription,


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to 🏁 Final Form!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/final-form/blob/main/.github/CONTRIBUTING.md

-->

This PR resolves #368.

Currently this issue will cause all typescript users cannot rely on the type declaration of `FormApi['submit']`. The return type of `FormApi['submit']` is wrong: When submit is async, the value of Promise should be `SubmissionErrors | undefined`, not `FormValues | undefined`.

Personally I found this error when I try to apply typescript in a project using final-form, and found out this brings a lot of tsc errors in codebase, which relies on returned submission errors heavily. Had to patch the fix in my project temporarily but not ideal.

@erikras it would be great if you could take a look for this one-line patch 🙏 

Also thanks @akozhemiakin raising #368 and suggest the fix 👍 
