### PR TITLE
Support 'constructor' and similar keys as field id's.

### DIFF
--- a/src/FinalForm.js
+++ b/src/FinalForm.js
@@ -184,8 +184,8 @@ function createForm<FormValues: FormValuesShape>(
 
   const state: InternalState<FormValues> = {
     subscribers: { index: 0, entries: {} },
-    fieldSubscribers: {},
-    fields: {},
+    fieldSubscribers: Object.create(null),
+    fields: Object.create(null),
     formState: {
       asyncErrors: {},
       dirtySinceLastSubmit: false,

--- a/src/FinalForm.registerField.test.js
+++ b/src/FinalForm.registerField.test.js
@@ -38,4 +38,17 @@ describe("FinalForm.registerField", () => {
     expect(typeof spy.mock.calls[0][0].focus).toBe("function");
     expect(typeof spy.mock.calls[0][0].change).toBe("function");
   });
+
+  it("should handle non-prototype fields correctly", () => {
+    const submitSpy = jest.fn();
+    const changeSpy = jest.fn();
+
+    const form = createForm({ onSubmit: submitSpy });
+    form.registerField("constructor", changeSpy);
+
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    form.change("constructor", "bar");
+    form.submit();
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
See https://github.com/final-form/final-form/issues/489
This is a fix for cases where acessing fields['constructor'] or fields['toString'],etc will throw you weird errors down the line.