### PR TITLE
Fix FormState.values type to be non-optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export interface FormState<
   touched?: { [key: string]: boolean };
   valid?: boolean;
   validating?: boolean;
-  values?: FormValues;
+  values: FormValues;
   visited?: { [key: string]: boolean };
 }
 


### PR DESCRIPTION
## Summary
• Fix FormState.values type definition to be non-optional
• Resolves TypeScript errors in v5 where consumers expect values to always be present

Fixes #501

## Test plan
- [x] All existing tests pass
- [x] TypeScript compilation succeeds
- [x] FormState.values is consistent with internal implementation where it's always initialized