### PR TITLE
Fix TypeScript error in isEqual initialization

### DIFF
--- a/src/FinalForm.ts
+++ b/src/FinalForm.ts
@@ -880,6 +880,7 @@ function createForm<
         afterSubmit: fieldConfig && fieldConfig.afterSubmit,
         beforeSubmit: fieldConfig && fieldConfig.beforeSubmit,
         data: (fieldConfig && fieldConfig.data) || {},
+        isEqual: tripleEquals,
         lastFieldState: undefined,
         modified: false,
         modifiedSinceLastSubmit: false,


### PR DESCRIPTION
## Problem
PR #480 introduced a TypeScript compilation error:
```
error TS2339: Property 'isEqual' does not exist on type...
```

This is breaking CI on all PRs because the prepare hook runs TypeScript compilation.

## Root Cause
The field object literal was missing the `isEqual` property in its initial definition (line 878-895), but it was being assigned later (line 902-905). TypeScript couldn't narrow the union type properly.

## Fix
Add `isEqual: tripleEquals` to the initial field object literal to match the `InternalFieldState` type.

## Verification
✅ `npx tsc --noEmit` now passes with no errors

## Urgency
🔥 **Blocking** - This breaks CI for all new PRs including #516 (size-limit migration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of form field comparisons to ensure all fields operate with standardized behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->