### PR TITLE
Fix #158: Guard against undefined field in getValidators

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     },
     {
       "path": "dist/final-form.cjs.js",
-      "limit": "6.51kB"
+      "limit": "6.55kB"
     }
   ],
   "types": "dist/index.d.ts"

--- a/src/FinalForm.ts
+++ b/src/FinalForm.ts
@@ -330,14 +330,18 @@ function createForm<
     return promises;
   };
 
-  const getValidators = (field: InternalFieldState) =>
-    Object.keys(field.validators).reduce((result, index) => {
+  const getValidators = (field: InternalFieldState) => {
+    if (!field || !field.validators) {
+      return [];
+    }
+    return Object.keys(field.validators).reduce((result, index) => {
       const validator = field.validators[Number(index)]();
       if (validator) {
         result.push(validator);
       }
       return result;
     }, []);
+  };
 
   const runFieldLevelValidation = (
     field: InternalFieldState,


### PR DESCRIPTION
Fixes react-final-form-arrays #158

**Problem:**
When array items are removed in react-final-form-arrays, validation attempts to access `field.validators` on field objects that have been deleted, causing the crash: "Cannot read property 'validators' of undefined"

**Root Cause:**
The `getValidators` function in FinalForm.ts didn't check if the field exists before accessing its `validators` property. After array items are removed, field keys may still exist while their corresponding field objects are undefined.

**Solution:**
Added a guard in `getValidators` to return an empty array if the field is undefined or doesn't have validators.

**Test:**
Added test "should not crash when validating after field with validator is unregistered" that:
- Registers a field with field-level validation
- Triggers validation
- Unregisters the field (simulating array item removal)
- Triggers another change that causes validation
- Verifies no crash occurs

All existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash during validation when a previously-validated field is removed; validation now safely handles missing fields.

* **Tests**
  * Added a regression test reproducing the remove-then-validate scenario to ensure no exceptions occur after unregistering a field.

* **Chores**
  * Updated build size-limit metadata to reflect the current bundle size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->