### PR TITLE
Fix #366: keepDirtyOnReinitialize with array fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     },
     {
       "path": "dist/final-form.cjs.js",
-      "limit": "6.55kB"
+      "limit": "6.62kB"
     }
   ],
   "types": "dist/index.d.ts"

--- a/src/FinalForm.arrays-keepdirty.test.ts
+++ b/src/FinalForm.arrays-keepdirty.test.ts
@@ -44,7 +44,6 @@ describe('FinalForm.keepDirtyOnReinitialize - Issue #366', () => {
     expect(getIn(form.getState().values, 'customers[0].firstName')).toBe('Modified')
 
     // But the pristine field should update to new initial value
-    // BUG: This fails - it keeps the old value 'Smith' instead of updating to 'NewSmith'
     expect(lastName1State.value).toBe('NewSmith')
   })
 })

--- a/src/FinalForm.arrays-keepdirty.test.ts
+++ b/src/FinalForm.arrays-keepdirty.test.ts
@@ -1,5 +1,4 @@
 import createForm from './FinalForm'
-import getIn from './structure/getIn'
 
 describe('FinalForm.keepDirtyOnReinitialize - Issue #366', () => {
   it('should update pristine array child fields when keepDirtyOnReinitialize is true', () => {
@@ -41,7 +40,7 @@ describe('FinalForm.keepDirtyOnReinitialize - Issue #366', () => {
     })
 
     // The modified field should keep its dirty value
-    expect(getIn(form.getState().values, 'customers[0].firstName')).toBe('Modified')
+    expect(firstName0State.value).toBe('Modified')
 
     // But the pristine field should update to new initial value
     expect(lastName1State.value).toBe('NewSmith')

--- a/src/FinalForm.arrays-keepdirty.test.ts
+++ b/src/FinalForm.arrays-keepdirty.test.ts
@@ -1,0 +1,50 @@
+import createForm from './FinalForm'
+import getIn from './structure/getIn'
+
+describe('FinalForm.keepDirtyOnReinitialize - Issue #366', () => {
+  it('should update pristine array child fields when keepDirtyOnReinitialize is true', () => {
+    const form = createForm({
+      onSubmit: () => {},
+      initialValues: {
+        customers: [
+          { firstName: 'John', lastName: 'Doe' },
+          { firstName: 'Jane', lastName: 'Smith' },
+        ],
+      },
+      keepDirtyOnReinitialize: true,
+    })
+
+    // Register array field (like final-form-arrays does)
+    form.registerField('customers', () => {}, { value: true })
+
+    // Register individual child fields
+    let firstName0State: any
+    form.registerField('customers[0].firstName', (state) => {
+      firstName0State = state
+    }, { value: true })
+
+    let lastName1State: any
+    form.registerField('customers[1].lastName', (state) => {
+      lastName1State = state
+    }, { value: true })
+
+    // Modify one child field
+    form.change('customers[0].firstName', 'Modified')
+    expect(firstName0State.value).toBe('Modified')
+
+    // Initialize with new data
+    form.initialize({
+      customers: [
+        { firstName: 'NewJohn', lastName: 'NewDoe' },
+        { firstName: 'NewJane', lastName: 'NewSmith' },
+      ],
+    })
+
+    // The modified field should keep its dirty value
+    expect(getIn(form.getState().values, 'customers[0].firstName')).toBe('Modified')
+
+    // But the pristine field should update to new initial value
+    // BUG: This fails - it keeps the old value 'Smith' instead of updating to 'NewSmith'
+    expect(lastName1State.value).toBe('NewSmith')
+  })
+})

--- a/src/FinalForm.ts
+++ b/src/FinalForm.ts
@@ -877,7 +877,14 @@ function createForm<
             getIn(formState.initialValues as object || {}, key),
           );
           if (!pristine) {
-            result[key] = getIn(formState.values as object, key);
+            // Check if any other registered field is a child of this field
+            // e.g., if key is "customers" and "customers[0].firstName" exists, skip "customers"
+            const hasChildFields = Object.keys(safeFields).some((otherKey) =>
+              otherKey !== key && (otherKey.startsWith(key + '[') || otherKey.startsWith(key + '.'))
+            );
+            if (!hasChildFields) {
+              result[key] = getIn(formState.values as object, key);
+            }
           }
           return result;
         }, {} as Record<string, any>)


### PR DESCRIPTION
**Problem:** When `keepDirtyOnReinitialize` is true and array fields are used (e.g., with final-form-arrays), pristine child fields don't update to new initial values. The parent array field's dirty value overwrites them.

**Root Cause:** When saving dirty values, the code saves ALL dirty fields including parent array fields (e.g., `customers`) AND their children (e.g., `customers[0].firstName`). When setting values back, the parent array value overwrites pristine children.

**Example Bug:**
```js
// Register both array field and children
form.registerField('customers', ...) // Array field
form.registerField('customers[0].firstName', ...) // Child
form.registerField('customers[1].lastName', ...) // Child

// Modify one child
form.change('customers[0].firstName', 'Modified')

// Reinitialize with new data
form.initialize({ customers: [
  { firstName: 'New1', lastName: 'NewLast1' },
  { firstName: 'New2', lastName: 'NewLast2' }
]})

// BUG: customers[1].lastName keeps old value instead of updating to 'NewLast2'
// because 'customers' array was saved as dirty and overwrote it
```

**Solution:** When saving dirty values, skip parent fields if child fields are registered. For example, if both `customers` and `customers[0].firstName` are registered, only save dirty values for the child fields.

This allows:
- ✅ Dirty children keep their modified values  
- ✅ Pristine children update to new initial values
- ✅ Parent array doesn't override children

**Testing:**
- Added test with array field + child fields
- Verifies modified child keeps value, pristine child updates  
- All existing tests pass

Fixes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined dirty-state persistence during form reinitialization so edits inside nested array fields are preserved while untouched values adopt new initial data.

* **Tests**
  * Added test coverage validating dirty-state behavior for nested array fields during reinitialization.

* **Chores**
  * Updated build metadata size limit for the distributed bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->