### PR TITLE
Add triggerValidation in FormApi

### DIFF
--- a/src/FinalForm.ts
+++ b/src/FinalForm.ts
@@ -1416,6 +1416,22 @@ function createForm<
     getFormSnapshot: (): FormState<FormValues, InitialFormValues> => {
       return calculateNextFormState();
     },
+
+    triggerValidation: (fields?: Array<keyof FormValues>) => {
+      if(!fields || fields === undefined || !Array.isArray(fields)) {
+        return runValidation(undefined, () => {
+          notifyFieldListeners(undefined);
+          notifyFormListeners();
+        });
+      };
+
+      fields.forEach((field) => {
+        runValidation(field as string, () => {
+          notifyFieldListeners(state.fields[field as string] ? field as string : undefined);
+          notifyFormListeners();
+        });
+      });
+    },
   };
   return api;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -210,4 +210,77 @@ describe("TypeScript types", () => {
     // Call the mutator
     mutators.setValue("firstName", "Kevin");
   });
+
+  test("triggerValidation", () => {
+    interface FormValues {
+      username: string;
+    };
+
+    const form = createForm<FormValues>({ 
+      onSubmit: jest.fn(),
+      validate(values) {
+        return values.username ? {} : { username: 'Required' }
+      },
+      initialValues: { username: '' }
+    });
+
+    form.triggerValidation();
+    expect(form.getState().errors?.username).toBe('Required');
+
+    form.change('username', 'test');
+    form.triggerValidation();
+    expect(form.getState().errors?.username).toBeUndefined();
+
+    interface FormValues2 extends FormValues {
+      phoneNumber: string;
+      email: string;
+    };
+
+    const setValue: Mutator<FormValues2> = (
+      [name, newValue],
+      state,
+      { changeValue },
+    ) => {
+      changeValue(state, name, () => newValue);
+    };
+
+    type Mutators = {
+      setValue: (name: string, value: string) => void;
+    };
+
+    const form2 = createForm<FormValues2>({
+      onSubmit: jest.fn(),
+      validate: () => {
+        return {
+          username: 'Required',
+          email: 'Required',
+          phoneNumber: 'Required'
+        }
+      },
+      initialValues: {
+        username: '',
+        email: '',
+        phoneNumber: ''
+      },
+      mutators: {
+       setValue
+      }
+    });
+
+    const mutators: Mutators = form2.mutators as Mutators;
+
+    form2.triggerValidation();
+
+    expect(form2.getState().errors?.username).toBe('Required');
+    expect(form2.getState().errors?.email).toBe('Required');
+    expect(form2.getState().errors?.phoneNumber).toBe('Required');
+
+    mutators.setValue('email', 'test@test.com');
+    mutators.setValue('phoneNumber', '1234567890');
+
+    form2.triggerValidation(["email", "phoneNumber"]);
+
+    expect(form2.getState().values?.email).toBe('test@test.com');
+    expect(form2.getState().values?.phoneNumber).toBe('1234567890');
+  })
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,6 +297,12 @@ export interface FormApi<
    */
   getFormSnapshot: () => FormState<FormValues, InitialFormValues>;
   ignoreUnregister: boolean;
+  /** 
+   * Run validation for all form fields or a specific field
+   * @param fields - array of field names to run validation for, if undefined it will run validation for all fields
+   * @returns void
+  */
+  triggerValidation: (fields?: Array<keyof FormValues>) => void
 }
 
 export type DebugFunction<


### PR DESCRIPTION
**Description**

Add triggerValidation to FromApi type to trigger validation for all fields or a specific fields.

**Feature Requested**
https://github.com/final-form/final-form/issues/439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `triggerValidation` method to the form API, enabling programmatic validation of all fields or specific subsets of form fields.

* **Tests**
  * Added test coverage for the new `triggerValidation` functionality across various validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->