### PR TITLE
ci: add npm publish workflow on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        run: yarn start test
+
+      - name: Build
+        run: yarn start build
+
+      - name: Publish
+        run: npm publish --provenance ${{ github.event.release.prerelease && '--tag next' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically publishes to npm whenever a GitHub Release is published.

## What it does
- Triggers on  (not on every tag push — requires an explicit GitHub Release to be published, giving you a manual checkpoint before anything hits npm)
- Runs tests and build first, then 
- Uses the  secret for authentication

## Prerequisites
An  secret needs to be added to this repo (or at the org level) before the workflow will work. Use a granular npm automation token scoped to publish access for this package only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated publishing workflow that runs tests and the build before publishing packages to npm when a release is published, and automatically tags prereleases as "next".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->