### PR TITLE
fix: remove runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@babel/core": "^7.27.1",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
-    "@babel/plugin-transform-runtime": "^7.27.1",
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-typescript": "^7.27.1",
     "@rollup/plugin-babel": "^6.0.4",
@@ -92,9 +91,6 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "dependencies": {
-    "@babel/runtime": "^7.10.0"
   },
   "resolutions": {
     "trim-newlines": "^3.0.1",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -73,7 +73,7 @@ export default {
     babel({
       exclude: "node_modules/**",
       babelrc: false,
-      babelHelpers: "runtime",
+      babelHelpers: "bundled",
       extensions: [".ts", ".js"],
       presets: [
         [
@@ -85,7 +85,6 @@ export default {
         ],
       ],
       plugins: [
-        ["@babel/plugin-transform-runtime", { useESModules: !cjs }],
         "@babel/plugin-syntax-dynamic-import",
         "@babel/plugin-syntax-import-meta",
       ],

--- a/src/packaging.test.ts
+++ b/src/packaging.test.ts
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+const rootDir = path.resolve(__dirname, "..");
+
+describe("packaging", () => {
+  it("does not declare runtime dependencies", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(rootDir, "package.json"), "utf8"),
+    );
+
+    expect(pkg.dependencies).toBeUndefined();
+    expect(JSON.stringify(pkg)).not.toContain("@babel/runtime");
+  });
+
+  it("builds with bundled Babel helpers", () => {
+    const rollupConfig = fs.readFileSync(
+      path.join(rootDir, "rollup.config.mjs"),
+      "utf8",
+    );
+
+    expect(rollupConfig).toContain('babelHelpers: "bundled"');
+    expect(rollupConfig).not.toContain("@babel/plugin-transform-runtime");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,7 +843,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-runtime@^7.16.4", "@babel/plugin-transform-runtime@^7.27.1":
+"@babel/plugin-transform-runtime@^7.16.4":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.27.1.tgz"
   integrity sha512-TqGF3desVsTcp3WrJGj4HfKokfCXCLcHpt4PJF0D8/iT6LPd9RS82Upw3KPeyr6B22Lfd3DO8MVrmp0oRkUDdw==
@@ -1040,7 +1040,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.27.1"
 
-"@babel/runtime@^7.10.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz"
   integrity sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==


### PR DESCRIPTION
## Summary
- bundle Babel helpers instead of importing @babel/runtime in generated artifacts
- remove @babel/runtime from runtime dependencies and update the lockfile
- add packaging regression tests for zero runtime dependencies and build config

## Test Plan
- yarn test
- yarn nps build
- grep -R "@babel/runtime" -n dist package.json rollup.config.mjs (no matches)

Closes #510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js requirement to version 18 or higher.
  * Cleaned up project dependencies and build configuration.

* **Tests**
  * Added packaging verification tests to ensure proper build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->