### PR TITLE
Add regression coverage for install lifecycle scripts

### DIFF
--- a/src/package.test.ts
+++ b/src/package.test.ts
@@ -1,0 +1,9 @@
+const packageJson = require("../package.json");
+
+describe("package scripts", () => {
+  test("does not define lifecycle install scripts", () => {
+    expect(packageJson.scripts).not.toHaveProperty("preinstall");
+    expect(packageJson.scripts).not.toHaveProperty("install");
+    expect(packageJson.scripts).not.toHaveProperty("postinstall");
+  });
+});


### PR DESCRIPTION
## Summary
- add regression coverage asserting the package does not define install lifecycle scripts
- guards against reintroducing the Yarn Berry postinstall eval failure reported in GH#431

Fixes #431

## Verification
- yarn test
- yarn nps build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test that validates package.json lifecycle scripts configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->