### PR TITLE
Fix FormApi.submit return type

### DIFF
--- a/src/FinalForm.ts
+++ b/src/FinalForm.ts
@@ -26,6 +26,7 @@ import {
   Subscriber,
   Subscribers,
   Subscription,
+  SubmissionErrors,
   Unsubscribe,
   StateFilter,
   AnyObject,
@@ -1247,7 +1248,7 @@ function createForm<
       callbackScheduler = scheduler;
     },
 
-    submit: (): Promise<FormValues | undefined> => {
+    submit: (): Promise<SubmissionErrors> => {
       const { formState } = state;
 
       if (formState.submitting) {
@@ -1289,7 +1290,7 @@ function createForm<
             console.error(err);
             return undefined;
           }
-        ) as Promise<FormValues | undefined>;
+        ) as Promise<SubmissionErrors>;
       }
 
       let resolvePromise: any
@@ -1336,7 +1337,7 @@ function createForm<
           // onSubmit is async with a Promise
           notifyFormListeners(); // let everyone know we are submitting
           notifyFieldListeners(undefined); // notify fields also
-          return (result as Promise<FormValues | undefined>).then(
+          return (result as Promise<SubmissionErrors>).then(
             (value) => {
               complete(value as AnyObject);
               return value;
@@ -1350,15 +1351,15 @@ function createForm<
           // must be async, so we should return a Promise
           notifyFormListeners(); // let everyone know we are submitting
           notifyFieldListeners(undefined); // notify fields also
-          return new Promise<FormValues | undefined>((resolve) => {
+          return new Promise<SubmissionErrors>((resolve) => {
             resolvePromise = resolve;
           });
         } else {
           // onSubmit is sync
-          complete(result as FormValues);
+          complete(result as SubmissionErrors);
         }
       }
-      return Promise.resolve(undefined as FormValues | undefined);
+      return Promise.resolve(undefined as SubmissionErrors);
     },
 
     subscribe: (

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,7 +254,7 @@ export interface FormApi<
     value: Config<FormValues, InitialFormValues>[K]
   ) => void;
   setCallbackScheduler: (scheduler?: (callback: () => void) => void) => void;
-  submit: () => Promise<FormValues | undefined> | undefined;
+  submit: () => Promise<SubmissionErrors> | undefined;
   subscribe: (
     subscriber: FormSubscriber<FormValues, InitialFormValues>,
     subscription: FormSubscription


### PR DESCRIPTION
Closes #368.\n\n## Summary\n- updates FormApi.submit to return SubmissionErrors instead of FormValues\n- aligns createForm's submit implementation annotations/casts with onSubmit's documented return value\n\n## Verification\n- yarn test\n- yarn nps typescript\n- yarn nps build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription methods to monitor field and form state changes in real time
  * Added snapshot methods to retrieve current field and form state
  * Enhanced form submission to support submission errors, improving error handling capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->