### PR TITLE
ci: update lock threads action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,8 +16,9 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      - uses: dessant/lock-threads@v6.0.2
         with:
+          process-only: "issues, prs"
           issue-inactive-days: "365"
           issue-lock-reason: "resolved"
           pr-inactive-days: "365"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,8 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6.0.2
+      # dessant/lock-threads@v6.0.2
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
         with:
           process-only: "issues, prs"
           issue-inactive-days: "365"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      # dessant/lock-threads@v6.0.2
+      # dessant/lock-threads pinned to commit 89ae32b08ed1a541efecbab17912962a5e38981c
       - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
         with:
           process-only: "issues, prs"


### PR DESCRIPTION
## Summary
- Updates dessant/lock-threads from v3 to v6.0.2
- Restricts the workflow to issues and PRs, matching the existing permissions
- Fixes the current failure from the old action rejecting GitHub's longer token and removes the Node 20 deprecation warning

## Test Plan
- Parsed .github/workflows/lock.yml with Ruby YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal CI workflow to use a pinned, newer revision of the repository-locking action for more reliable automated maintenance and consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/final-form/final-form/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->